### PR TITLE
Verify the signature of any incoming payload to certify its origin

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -29,6 +29,15 @@
         }
       },
       {
+        "package": "CryptoSwift",
+        "repositoryURL": "https://github.com/krzyzanowskim/CryptoSwift.git",
+        "state": {
+          "branch": null,
+          "revision": "3a2acbb32ab68215ee1596ee6004da8e90c3721b",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "DatabaseKit",
         "repositoryURL": "https://github.com/vapor/database-kit.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,11 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "3.0.0"),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift.git", from: "5.0.0"),
-        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0")
+        .package(url: "https://github.com/Quick/Nimble.git", from: "8.0.0"),
+        .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", from: "1.0.0")
     ],
     targets: [
-        .target(name: "Bot", dependencies: ["ReactiveSwift"]),
+        .target(name: "Bot", dependencies: ["ReactiveSwift", "CryptoSwift"]),
         .target(name: "App", dependencies: ["Bot", "Vapor"]),
         .target(name: "Run", dependencies: ["App"]),
         .testTarget(name: "BotTests", dependencies: ["Bot", "Nimble"])

--- a/Sources/App/Extensions/Vapor.Request+RequestProtocol.swift
+++ b/Sources/App/Extensions/Vapor.Request+RequestProtocol.swift
@@ -18,7 +18,7 @@ extension Vapor.Request: RequestProtocol {
 
     public func decodeBody<T>(
         _ type: T.Type,
-        using scheduler: QueueScheduler
+        using scheduler: Scheduler
     ) -> SignalProducer<T, AnyError> where T: Decodable {
         return SignalProducer { [content] observer, disposable in
             guard disposable.hasEnded == false else { return }

--- a/Sources/App/Extensions/Vapor.Request+RequestProtocol.swift
+++ b/Sources/App/Extensions/Vapor.Request+RequestProtocol.swift
@@ -4,7 +4,14 @@ import Vapor
 import Result
 import ReactiveSwift
 
+extension Vapor.HTTPBody: HTTPBodyProtocol {}
+
 extension Vapor.Request: RequestProtocol {
+
+    public var body: HTTPBodyProtocol {
+        return self.http.body
+    }
+
     public func header(named name: String) -> String? {
         return http.headers[name].first
     }

--- a/Sources/App/app.swift
+++ b/Sources/App/app.swift
@@ -10,3 +10,7 @@ public func app(_ env: Environment) throws -> Application {
     try boot(app)
     return app
 }
+
+extension Environment {
+    static let githubWebhookSecret = Environment.get("GITHUB_WEBHOOK_SECRET")
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -1,10 +1,17 @@
 import Bot
 import Vapor
 
+enum ConfigurationError: Error {
+    case missingCOnfiguration(message: String)
+}
+
 /// Called before your application initializes.
 public func configure(_ config: inout Config, _ env: inout Environment, _ services: inout Services) throws {
 
-    let gitHubService = GitHubService()
+    guard let githubWebhookSecret = Environment.githubWebhookSecret
+        else { throw ConfigurationError.missingCOnfiguration(message: "💥 GitHub Webhook Secret is missing")}
+
+    let gitHubService = GitHubService(signatureToken: githubWebhookSecret)
 
     // Register routes to the router
     let router = EngineRouter.default()

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -2,14 +2,14 @@ import Bot
 import Vapor
 
 enum ConfigurationError: Error {
-    case missingCOnfiguration(message: String)
+    case missingConfiguration(message: String)
 }
 
 /// Called before your application initializes.
 public func configure(_ config: inout Config, _ env: inout Environment, _ services: inout Services) throws {
 
     guard let githubWebhookSecret = Environment.githubWebhookSecret
-        else { throw ConfigurationError.missingCOnfiguration(message: "💥 GitHub Webhook Secret is missing")}
+        else { throw ConfigurationError.missingConfiguration(message: "💥 GitHub Webhook Secret is missing")}
 
     let gitHubService = GitHubService(signatureToken: githubWebhookSecret)
 

--- a/Sources/Bot/Network/Request.swift
+++ b/Sources/Bot/Network/Request.swift
@@ -2,7 +2,13 @@ import Foundation
 import Result
 import ReactiveSwift
 
+public protocol HTTPBodyProtocol {
+    var data: Data? { get }
+}
+
 public protocol RequestProtocol {
+    var body: HTTPBodyProtocol { get }
+
     func header(named name: String) -> String?
     func decodeBody<T>(
         _ type: T.Type,

--- a/Sources/Bot/Network/Request.swift
+++ b/Sources/Bot/Network/Request.swift
@@ -12,6 +12,6 @@ public protocol RequestProtocol {
     func header(named name: String) -> String?
     func decodeBody<T>(
         _ type: T.Type,
-        using scheduler: QueueScheduler
+        using scheduler: Scheduler
     ) -> SignalProducer<T, AnyError> where T: Decodable
 }

--- a/Sources/Bot/Services/GitHubService.swift
+++ b/Sources/Bot/Services/GitHubService.swift
@@ -55,6 +55,8 @@ public final class GitHubService {
         with token: Token
     ) -> (RequestProtocol) -> Result<RequestProtocol, EventHandlingError> {
 
+        // This was implemented following this reference: https://developer.github.com/webhooks/securing/
+
         return { request in
             guard
                 let signature = request.header(.signature),

--- a/Sources/Bot/Services/GitHubService.swift
+++ b/Sources/Bot/Services/GitHubService.swift
@@ -17,12 +17,12 @@ public final class GitHubService {
 
     public typealias Token = String
 
-    private let scheduler: QueueScheduler
+    private let scheduler: Scheduler
     private let signatureVerifier: (RequestProtocol) -> Result<RequestProtocol, EventHandlingError>
     private let eventsObserver: Signal<Event, NoError>.Observer
     public let events: Signal<Event, NoError>
 
-    public init(signatureToken: Token, scheduler: QueueScheduler = QueueScheduler()) {
+    public init(signatureToken: Token, scheduler: Scheduler = QueueScheduler()) {
         self.signatureVerifier = GitHubService.signatureVerifier()(signatureToken)
         self.scheduler = scheduler
         (events, eventsObserver) = Signal.pipe()

--- a/Sources/Bot/Services/GitHubService.swift
+++ b/Sources/Bot/Services/GitHubService.swift
@@ -1,11 +1,13 @@
 import Foundation
 import ReactiveSwift
 import Result
+import CryptoSwift
 
 public final class GitHubService {
 
     internal enum HTTPHeader: String {
         case event = "X-GitHub-Event"
+        case signature = "X-Hub-Signature"
     }
 
     internal enum APIEvent: String {
@@ -13,17 +15,22 @@ public final class GitHubService {
         case ping
     }
 
+    public typealias Token = String
+
     private let scheduler: QueueScheduler
+    private let signatureVerifier: (RequestProtocol) -> Result<RequestProtocol, EventHandlingError>
     private let eventsObserver: Signal<Event, NoError>.Observer
     public let events: Signal<Event, NoError>
 
-    public init(scheduler: QueueScheduler = QueueScheduler()) {
+    public init(signatureToken: Token, scheduler: QueueScheduler = QueueScheduler()) {
+        self.signatureVerifier = GitHubService.signatureVerifier()(signatureToken)
         self.scheduler = scheduler
         (events, eventsObserver) = Signal.pipe()
     }
 
     public func handleEvent(from request: RequestProtocol) -> SignalProducer<Void, EventHandlingError> {
-        return parseEvent(from: request)
+        return SignalProducer { [signatureVerifier] in signatureVerifier(request) }
+            .flatMap(.latest, parseEvent)
             .on(value: eventsObserver.send(value:))
             .map { _ in }
     }
@@ -43,10 +50,37 @@ public final class GitHubService {
             return SignalProducer(error: .unknown)
         }
     }
+
+    private static func signatureVerifier(
+    ) -> (Token) -> (RequestProtocol) -> Result<RequestProtocol, EventHandlingError> {
+
+        return { token in
+            return { request in
+                guard
+                    let signature = request.header(.signature),
+                    let digest = signature.range(of: "sha1=")
+                        .map({ signature[$0.upperBound..<signature.endIndex] })
+                        .map(String.init)
+                        .map(Array.init(hex:))
+                    else { return .failure(.untrustworthy) }
+
+                guard
+                    let bodyData = request.body.data,
+                    let computedDigest = try? HMAC(key: token, variant: .sha1).authenticate(bodyData.bytes)
+                    else { return .failure(.untrustworthy) }
+
+                guard computedDigest == digest
+                    else { return .failure(.untrustworthy) }
+
+                return .success(request)
+            }
+        }
+    }
 }
 
 extension GitHubService {
     public enum EventHandlingError: Error {
+        case untrustworthy
         case invalid
         case unknown
     }

--- a/Tests/BotTests/GitHub/GitHubEventsTests.swift
+++ b/Tests/BotTests/GitHub/GitHubEventsTests.swift
@@ -2,24 +2,35 @@ import XCTest
 import Nimble
 import Result
 import ReactiveSwift
+import CryptoSwift
 @testable import Bot
 
 class GitHubEventsTests: XCTestCase {
 
+    let signatureToken = "Wall-E"
+
+    private func signature(for data: Data) -> String {
+        let signature = try! HMAC(key: signatureToken, variant: .sha1)
+            .authenticate(data.bytes)
+            .toHexString()
+
+        return "sha1=\(signature)"
+    }
+
     func test_handling_pull_request_event() {
-        let service = GitHubService()
+        let service = GitHubService(signatureToken: signatureToken)
         let scheduler = TestScheduler()
 
         let pullRequestEvent = PullRequestEvent(
-            action: .opened,
+            action: .closed,
             pullRequestMetadata: PullRequestMetadata(
                 reference: PullRequest(
                     number: 1,
-                    title: "Hello World",
-                    author: PullRequest.Author(login: "Wall-E Bot"),
-                    source: PullRequest.Branch(ref: "some-feature", sha: "123"),
-                    target: PullRequest.Branch(ref: "master", sha: "123"),
-                    labels: []
+                    title: "Update the README with new information",
+                    author: PullRequest.Author(login: "Codertocat"),
+                    source: PullRequest.Branch(ref: "changes", sha: "34c5c7793cb3b279e22454cb6750c80560547b3a"),
+                    target: PullRequest.Branch(ref: "master", sha: "a10867b14bb761a232cd80139fbd4c0d33264240"),
+                    labels: [.init(name: "bug")]
                 ),
                 isMerged: false,
                 mergeState: .clean
@@ -27,8 +38,11 @@ class GitHubEventsTests: XCTestCase {
         )
 
         let request = StubbedRequest(
-            headers: [GitHubService.HTTPHeader.event.rawValue: GitHubService.APIEvent.pullRequest.rawValue],
-            body: pullRequestEvent
+            headers: [
+                GitHubService.HTTPHeader.event.rawValue: GitHubService.APIEvent.pullRequest.rawValue,
+                GitHubService.HTTPHeader.signature.rawValue: signature(for: GitHubPullRequestEvent.data(using: .utf8)!)
+            ],
+            data: GitHubPullRequestEvent.data(using: .utf8)!
         )
 
         var observedEvents: [Event] = []
@@ -46,12 +60,18 @@ class GitHubEventsTests: XCTestCase {
     }
 
     func test_handling_ping_event() {
-        let service = GitHubService()
+        let service = GitHubService(signatureToken: signatureToken)
         let scheduler = TestScheduler()
 
+        // NOTE: I'm unsure about the payload of this specific event
+        let payload = "{}".data(using: .utf8)!
+
         let request = StubbedRequest(
-            headers: [GitHubService.HTTPHeader.event.rawValue: GitHubService.APIEvent.ping.rawValue],
-            body: nil
+            headers: [
+                GitHubService.HTTPHeader.event.rawValue: GitHubService.APIEvent.ping.rawValue,
+                GitHubService.HTTPHeader.signature.rawValue: signature(for: payload)
+            ],
+            data: payload
         )
 
         var observedEvents: [Event] = []
@@ -69,16 +89,34 @@ class GitHubEventsTests: XCTestCase {
     }
 
     func test_handling_unknown_event() {
-        let service = GitHubService()
+        let service = GitHubService(signatureToken: signatureToken)
+
+        let payload = "{}".data(using: .utf8)!
 
         let request = StubbedRequest(
-            headers: [GitHubService.HTTPHeader.event.rawValue : "anything_really"],
-            body: nil
+            headers: [
+                GitHubService.HTTPHeader.event.rawValue : "anything_really",
+                GitHubService.HTTPHeader.signature.rawValue: signature(for: payload)
+            ],
+            data: payload
         )
 
         let result = service.handleEvent(from: request).first()
 
         expect(result?.error) == .unknown
+    }
+
+    func test_handling_untrustworthy_payload() {
+        let service = GitHubService(signatureToken: signatureToken)
+
+        let request = StubbedRequest(
+            headers: [GitHubService.HTTPHeader.event.rawValue : "anything_really"],
+            data: nil
+        )
+
+        let result = service.handleEvent(from: request).first()
+
+        expect(result?.error) == .untrustworthy
     }
 }
 
@@ -87,9 +125,13 @@ extension GitHubEventsTests {
         case invalid
     }
 
-    fileprivate struct StubbedRequest: RequestProtocol {
+    fileprivate struct StubbedRequest: RequestProtocol, HTTPBodyProtocol {
         let headers: [String: String]
-        let body: Any?
+        let data: Data?
+
+        var body: HTTPBodyProtocol {
+            return self
+        }
 
         func header(named name: String) -> String? {
             return headers[name]
@@ -99,9 +141,14 @@ extension GitHubEventsTests {
             _ type: T.Type,
             using scheduler: QueueScheduler
         ) -> SignalProducer<T, AnyError> where T: Decodable {
-            switch body as? T {
-            case let .some(value):
-                return SignalProducer(value: value)
+            switch data {
+            case let .some(data):
+                let decoder = JSONDecoder()
+                do {
+                    return SignalProducer(value: try decoder.decode(T.self, from: data))
+                } catch {
+                    return SignalProducer(error: AnyError(DecodeError.invalid))
+                }
             case .none:
                 return SignalProducer(error: AnyError(DecodeError.invalid))
             }

--- a/Tests/BotTests/GitHub/GitHubEventsTests.swift
+++ b/Tests/BotTests/GitHub/GitHubEventsTests.swift
@@ -97,12 +97,6 @@ extension GitHubEventsTests {
     
     static let signatureToken = "Wall-E"
 
-    private func signature(for data: Data) -> String {
-        return try! HMAC(key: GitHubEventsTests.signatureToken, variant: .sha1)
-            .authenticate(data.bytes)
-            .toHexString()
-    }
-
     private var stubbedPullRequestEvent: PullRequestEvent {
         return PullRequestEvent(
             action: .closed,

--- a/Tests/BotTests/GitHub/GitHubEventsTests.swift
+++ b/Tests/BotTests/GitHub/GitHubEventsTests.swift
@@ -190,15 +190,13 @@ extension GitHubEventsTests {
             _ type: T.Type,
             using scheduler: Scheduler
         ) -> SignalProducer<T, AnyError> where T: Decodable {
-            switch data {
-            case let .some(data):
+            guard let data = data
+                else { return SignalProducer(error: AnyError(DecodeError.invalid)) }
+
+            do {
                 let decoder = JSONDecoder()
-                do {
-                    return SignalProducer(value: try decoder.decode(T.self, from: data))
-                } catch {
-                    return SignalProducer(error: AnyError(DecodeError.invalid))
-                }
-            case .none:
+                return SignalProducer(value: try decoder.decode(T.self, from: data))
+            } catch {
                 return SignalProducer(error: AnyError(DecodeError.invalid))
             }
         }


### PR DESCRIPTION
### Why?

Every payload coming from webhooks should be signed at the origin and verified when received to certify its origin, as a security procedure. This is done by verifying the body of the request with the secret configured by us on GitHub.

The reference for this verification can be found [here](https://developer.github.com/webhooks/securing/).