### PR TITLE
Fix Heroku configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: App --env=debug --workdir="./"
+web: Run --env production --hostname 0.0.0.0 --port $PORT


### PR DESCRIPTION
### Why?

The app is currently crashing because it was configured for Vapor 2 instead of 3 which is slightly different.

I'm following the reference from [here](https://github.com/vapor-community/heroku-buildpack) without the `serve`, Stevenson does not seem to be use it either.

```
heroku[web.1]: Starting process with command `App --env=debug --workdir="./"`
heroku[web.1]: State changed from starting to crashed
heroku[web.1]: Process exited with status 127
app[web.1]: bash: App: command not found
```