### PR TITLE
Adopt the usage of services

### DIFF
--- a/Sources/App/app.swift
+++ b/Sources/App/app.swift
@@ -10,7 +10,3 @@ public func app(_ env: Environment) throws -> Application {
     try boot(app)
     return app
 }
-
-extension Environment {
-    static let githubWebhookSecret = Environment.get("GITHUB_WEBHOOK_SECRET")
-}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -12,14 +12,21 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
 
     logger.log("👟 Starting up...")
 
-    guard let githubWebhookSecret = Environment.githubWebhookSecret
-        else { throw ConfigurationError.missingConfiguration(message: "💥 GitHub Webhook Secret is missing")}
+    services.register(logger, as: LoggerProtocol.self)
 
-    let gitHubService = GitHubService(signatureToken: githubWebhookSecret)
+    services.register(GitHubService.self) { container -> GitHubService in
+
+        logger.log("⏳ Initializing `GitHubService`...")
+
+        guard let githubWebhookSecret = Environment.githubWebhookSecret
+            else { throw ConfigurationError.missingConfiguration(message: "💥 GitHub Webhook Secret is missing")}
+
+        return GitHubService(signatureToken: githubWebhookSecret)
+    }
 
     // Register routes to the router
     let router = EngineRouter.default()
-    try routes(router, logger: logger, gitHubService: gitHubService)
+    try routes(router)
     services.register(router, as: Router.self)
 
     // Register middleware
@@ -30,3 +37,10 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
 
     logger.log("🏁 Ready")
 }
+
+extension Environment {
+    static let githubWebhookSecret = Environment.get("GITHUB_WEBHOOK_SECRET")
+}
+
+extension GitHubService: Service {}
+extension PrintLogger: Service {}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,13 +1,16 @@
 import Bot
 import Vapor
 
-public func routes(_ router: Router, logger: LoggerProtocol, gitHubService: GitHubService) throws {
+public func routes(_ router: Router) throws {
 
     router.post("github") { request -> HTTPResponse in
 
+        let logger = try request.make(LoggerProtocol.self)
+        let service = try request.make(GitHubService.self)
+
         logger.log("📨 handling event: \(request)")
 
-        switch gitHubService.handleEvent(from: request).first() {
+        switch service.handleEvent(from: request).first() {
         case .success?:
             return HTTPResponse(status: .ok)
         case .failure?, .none:


### PR DESCRIPTION
## Why?

Disclaimer: this change is needed for the work being done in #12 and only affects the current implementation/infrastructure so can and should be reviewed in insolation. 

`GitHubService` will require a HTTP client to interact with the GitHub API as part of the work being done in #12 which is included in Vapor so we need to make a couple of changes to accommodate its usage.

## How?

The `HTTPClient` part of Vapor needs to, or ideally should, be created from a `Container` which can be either the `Application` or the `Request`. Because `GitHubService` will be an instance that we want to set-up once and reuse in any incoming request the only good candidate for our use case would be using the `Application`. But we can't because `Application` is only created after we configure and register everything and we can't register a new additional service.

The only alternative is to use Vapor's [Services](https://docs.vapor.codes/3.0/getting-started/services/#environment) which are in essence a `ServiceLocator` providing methods to register instances or factory methods that receive the inner `Container` allowing the correct initialisation and configuration of each Service.

Adopting this in our case is relatively trivial, instead of carrying the dependencies manually to the routing system we can register each service and then retrieve them for each request as needed. Because in #12 we will need the container to set-up a HTTP client we are already using the factory method that receives the container and creates the service.

`GitHubService` in this case will be a lazy service, it will be initialized on first request and then reused in the following ones which fits our purpose of keeping just a single entity during the entire lifecycle of the app.