### PR TITLE
[CNSMR-2254] Complete the transition to make Wall-E ready to be used

### DIFF
--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -1,0 +1,32 @@
+import Vapor
+import Bot
+
+extension Environment {
+
+    static func gitHubWebhookSecret() throws -> String {
+        return try Environment.get("GITHUB_WEBHOOK_SECRET")
+    }
+
+    static func gitHubToken() throws -> String {
+        return try Environment.get("GITHUB_TOKEN")
+    }
+
+    static func gitHubOrganization() throws -> String {
+        return try Environment.get("GITHUB_ORGANIZATION")
+    }
+
+    static func gitHubRepository() throws -> String {
+        return try Environment.get("GITHUB_REPOSITORY")
+    }
+
+    static func mergeLabel() throws -> PullRequest.Label {
+        return PullRequest.Label(name: try Environment.get("MERGE_LABEL"))
+    }
+
+    static func get(_ key: String) throws -> String {
+        guard let value = Environment.get(key) as String?
+            else { throw ConfigurationError.missingConfiguration(message: "💥 key `\(key)` not found in environment") }
+
+        return value
+    }
+}

--- a/Sources/App/app.swift
+++ b/Sources/App/app.swift
@@ -10,7 +10,3 @@ public func app(_ env: Environment) throws -> Application {
     try boot(app)
     return app
 }
-
-extension Environment {
-    static let githubWebhookSecret = Environment.get("GITHUB_WEBHOOK_SECRET")
-}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -42,34 +42,4 @@ private func makeMergeService(with logger: LoggerProtocol, _ gitHubEventsService
     )
 }
 
-extension Environment {
-
-    static func gitHubWebhookSecret() throws -> String {
-        return try Environment.get("GITHUB_WEBHOOK_SECRET")
-    }
-
-    static func gitHubToken() throws -> String {
-        return try Environment.get("GITHUB_TOKEN")
-    }
-
-    static func gitHubOrganization() throws -> String {
-        return try Environment.get("GITHUB_ORGANIZATION")
-    }
-
-    static func gitHubRepository() throws -> String {
-        return try Environment.get("GITHUB_REPOSITORY")
-    }
-
-    static func mergeLabel() throws -> PullRequest.Label {
-        return PullRequest.Label(name: try Environment.get("MERGE_LABEL"))
-    }
-
-    static func get(_ key: String) throws -> String {
-        guard let value = Environment.get(key) as String?
-            else { throw ConfigurationError.missingConfiguration(message: "💥 key `\(key)` not found in environment") }
-
-        return value
-    }
-}
-
 extension MergeService: Service {}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -9,17 +9,15 @@ enum ConfigurationError: Error {
 public func configure(_ config: inout Config, _ env: inout Environment, _ services: inout Services) throws {
 
     let logger = PrintLogger()
+    let gitHubEventsService = GitHubEventsService(signatureToken: try Environment.gitHubWebhookSecret())
 
     logger.log("👟 Starting up...")
 
-    guard let githubWebhookSecret = Environment.githubWebhookSecret
-        else { throw ConfigurationError.missingConfiguration(message: "💥 GitHub Webhook Secret is missing")}
-
-    let gitHubService = GitHubService(signatureToken: githubWebhookSecret)
+    services.register(try makeMergeService(with: logger, gitHubEventsService))
 
     // Register routes to the router
     let router = EngineRouter.default()
-    try routes(router, logger: logger, gitHubService: gitHubService)
+    try routes(router, logger: logger, gitHubEventsService: gitHubEventsService)
     services.register(router, as: Router.self)
 
     // Register middleware
@@ -30,3 +28,48 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
 
     logger.log("🏁 Ready")
 }
+
+private func makeMergeService(with logger: LoggerProtocol, _ gitHubEventsService: GitHubEventsService) throws -> MergeService {
+
+    let gitHubAPI = GitHubClient(session: URLSession(configuration: .default), token: try Environment.gitHubToken())
+        .api(for: Repository(owner: try Environment.gitHubOrganization(), name: try Environment.gitHubRepository()))
+
+    return MergeService(
+        integrationLabel: try Environment.mergeLabel(),
+        logger: logger,
+        gitHubAPI: gitHubAPI,
+        gitHubEvents: gitHubEventsService
+    )
+}
+
+extension Environment {
+
+    static func gitHubWebhookSecret() throws -> String {
+        return try Environment.get("GITHUB_WEBHOOK_SECRET")
+    }
+
+    static func gitHubToken() throws -> String {
+        return try Environment.get("GITHUB_TOKEN")
+    }
+
+    static func gitHubOrganization() throws -> String {
+        return try Environment.get("GITHUB_ORGANIZATION")
+    }
+
+    static func gitHubRepository() throws -> String {
+        return try Environment.get("GITHUB_REPOSITORY")
+    }
+
+    static func mergeLabel() throws -> PullRequest.Label {
+        return PullRequest.Label(name: try Environment.get("MERGE_LABEL"))
+    }
+
+    static func get(_ key: String) throws -> String {
+        guard let value = Environment.get(key) as String?
+            else { throw ConfigurationError.missingConfiguration(message: "💥 key `\(key)` not found in environment") }
+
+        return value
+    }
+}
+
+extension MergeService: Service {}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,13 +1,13 @@
 import Bot
 import Vapor
 
-public func routes(_ router: Router, logger: LoggerProtocol, gitHubService: GitHubService) throws {
+public func routes(_ router: Router, logger: LoggerProtocol, gitHubEventsService: GitHubEventsService) throws {
 
     router.post("github") { request -> HTTPResponse in
 
         logger.log("📨 handling event: \(request)")
 
-        switch gitHubService.handleEvent(from: request).first() {
+        switch gitHubEventsService.handleEvent(from: request).first() {
         case .success?:
             return HTTPResponse(status: .ok)
         case .failure?, .none:

--- a/Sources/Bot/API/RepositoryAPI.swift
+++ b/Sources/Bot/API/RepositoryAPI.swift
@@ -54,3 +54,10 @@ public struct RepositoryAPI: GitHubAPIProtocol {
             .mapError(AnyError.init)
     }
 }
+
+extension GitHubClient {
+
+    public func api(for repository: Repository) -> RepositoryAPI {
+        return RepositoryAPI(client: self, repository: repository)
+    }
+}

--- a/Sources/Bot/Models/Event.swift
+++ b/Sources/Bot/Models/Event.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum Event: Equatable {
     case pullRequest(PullRequestEvent)
+    case status(StatusChange)
     case ping
 }
 

--- a/Sources/Bot/Models/Event.swift
+++ b/Sources/Bot/Models/Event.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum Event: Equatable {
     case pullRequest(PullRequestEvent)
-    case status(StatusChange)
+    case status(StatusEvent)
     case ping
 }
 

--- a/Sources/Bot/Models/PullRequest.swift
+++ b/Sources/Bot/Models/PullRequest.swift
@@ -18,6 +18,10 @@ extension PullRequest {
 extension PullRequest {
     public struct Label: Equatable, Decodable {
         public let name: String
+
+        public init(name: String) {
+            self.name = name
+        }
     }
 }
 

--- a/Sources/Bot/Models/StatusEvent.swift
+++ b/Sources/Bot/Models/StatusEvent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public struct StatusChange: Equatable, Decodable {
+public struct StatusEvent: Equatable, Decodable {
     let sha: String
     let context: String
     let description: String?

--- a/Sources/Bot/Services/GitHubEventsService.swift
+++ b/Sources/Bot/Services/GitHubEventsService.swift
@@ -3,7 +3,11 @@ import ReactiveSwift
 import Result
 import CryptoSwift
 
-public final class GitHubService {
+public protocol GitHubEventsServiceProtocol {
+    var events: Signal<Event, NoError> { get }
+}
+
+public final class GitHubEventsService: GitHubEventsServiceProtocol {
 
     internal enum HTTPHeader: String {
         case event = "X-GitHub-Event"
@@ -24,7 +28,7 @@ public final class GitHubService {
     public let events: Signal<Event, NoError>
 
     public init(signatureToken: Token, scheduler: Scheduler = QueueScheduler()) {
-        self.signatureVerifier = GitHubService.signatureVerifier(with: signatureToken)
+        self.signatureVerifier = GitHubEventsService.signatureVerifier(with: signatureToken)
         self.scheduler = scheduler
         (events, eventsObserver) = Signal.pipe()
     }
@@ -89,7 +93,7 @@ public final class GitHubService {
     }
 }
 
-extension GitHubService {
+extension GitHubEventsService {
     public enum EventHandlingError: Error {
         case untrustworthy
         case invalid
@@ -98,7 +102,7 @@ extension GitHubService {
 }
 
 private extension RequestProtocol {
-    func header(_ header: GitHubService.HTTPHeader) -> String? {
+    func header(_ header: GitHubEventsService.HTTPHeader) -> String? {
         return self.header(named: header.rawValue)
     }
 }

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -13,8 +13,8 @@ public final class MergeService {
     private let pullRequestChanges: Signal<(PullRequestMetadata, PullRequest.Action), NoError>
     private let pullRequestChangesObserver: Signal<(PullRequestMetadata, PullRequest.Action), NoError>.Observer
 
-    private let statusChecksCompletion: Signal<StatusChange, NoError>
-    private let statusChecksCompletionObserver: Signal<StatusChange, NoError>.Observer
+    private let statusChecksCompletion: Signal<StatusEvent, NoError>
+    private let statusChecksCompletionObserver: Signal<StatusEvent, NoError>.Observer
 
     public init(
         integrationLabel: PullRequest.Label,
@@ -59,7 +59,7 @@ public final class MergeService {
         pullRequestChangesObserver.send(value: (metadata, action))
     }
 
-    func statusChecksDidChange(change: StatusChange) {
+    func statusChecksDidChange(change: StatusEvent) {
         statusChecksCompletionObserver.send(value: change)
     }
 
@@ -264,7 +264,7 @@ extension MergeService {
     fileprivate static func whenRunningStatusChecks(
         github: GitHubAPIProtocol,
         logger: LoggerProtocol,
-        statusChecksCompletion: Signal<StatusChange, NoError>,
+        statusChecksCompletion: Signal<StatusEvent, NoError>,
         scheduler: DateScheduler
     ) -> Feedback<State, Event> {
 

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -7,7 +7,7 @@ public final class MergeService {
     let state: Property<State>
 
     private let logger: LoggerProtocol
-    private let github: GitHubAPIProtocol
+    private let gitHubAPI: GitHubAPIProtocol
     private let scheduler: DateScheduler
 
     private let pullRequestChanges: Signal<(PullRequestMetadata, PullRequest.Action), NoError>
@@ -20,12 +20,12 @@ public final class MergeService {
         integrationLabel: PullRequest.Label,
         statusChecksTimeout: TimeInterval = 60.minutes,
         logger: LoggerProtocol,
-        github: GitHubAPIProtocol,
+        gitHubAPI: GitHubAPIProtocol,
         scheduler: DateScheduler = QueueScheduler()
     ) {
 
         self.logger = logger
-        self.github = github
+        self.gitHubAPI = gitHubAPI
         self.scheduler = scheduler
 
         (statusChecksCompletion, statusChecksCompletionObserver) = Signal.pipe()
@@ -37,13 +37,13 @@ public final class MergeService {
             scheduler: scheduler,
             reduce: MergeService.reduce,
             feedbacks: [
-                Feedbacks.whenStarting(github: self.github, scheduler: scheduler),
-                Feedbacks.whenReady(github: self.github, scheduler: scheduler),
-                Feedbacks.whenIntegrating(github: self.github, pullRequestChanges: pullRequestChanges, scheduler: scheduler),
-                Feedbacks.whenRunningStatusChecks(github: self.github, logger: logger, statusChecksCompletion: statusChecksCompletion, scheduler: scheduler),
-                Feedbacks.whenIntegrationFailed(github: self.github, logger: logger, scheduler: scheduler),
+                Feedbacks.whenStarting(github: self.gitHubAPI, scheduler: scheduler),
+                Feedbacks.whenReady(github: self.gitHubAPI, scheduler: scheduler),
+                Feedbacks.whenIntegrating(github: self.gitHubAPI, pullRequestChanges: pullRequestChanges, scheduler: scheduler),
+                Feedbacks.whenRunningStatusChecks(github: self.gitHubAPI, logger: logger, statusChecksCompletion: statusChecksCompletion, scheduler: scheduler),
+                Feedbacks.whenIntegrationFailed(github: self.gitHubAPI, logger: logger, scheduler: scheduler),
                 Feedbacks.pullRequestChanges(pullRequestChanges: pullRequestChanges, scheduler: scheduler),
-                Feedbacks.whenAddingPullRequests(github: self.github, scheduler: scheduler)
+                Feedbacks.whenAddingPullRequests(github: self.gitHubAPI, scheduler: scheduler)
             ]
         )
 

--- a/Tests/BotTests/GitHub/GitHubDecodingTests.swift
+++ b/Tests/BotTests/GitHub/GitHubDecodingTests.swift
@@ -46,15 +46,15 @@ class GitHubDecodingTests: XCTestCase {
         let data = GitHubStatusEvent.data(using: .utf8)!
 
         do {
-            let statusChange = try decoder.decode(StatusChange.self, from: data)
+            let statusChange = try decoder.decode(StatusEvent.self, from: data)
             expect(statusChange.sha) == "a10867b14bb761a232cd80139fbd4c0d33264240"
             expect(statusChange.context) == "default"
             expect(statusChange.description).to(beNil())
             expect(statusChange.state) == .success
             expect(statusChange.branches) == [
-                StatusChange.Branch(name: "master"),
-                StatusChange.Branch(name: "changes"),
-                StatusChange.Branch(name: "gh-pages")
+                StatusEvent.Branch(name: "master"),
+                StatusEvent.Branch(name: "changes"),
+                StatusEvent.Branch(name: "gh-pages")
             ]
         } catch let error {
             fail("Could not parse a pull request with error: \(error)")

--- a/Tests/BotTests/GitHub/GitHubEventsTests.swift
+++ b/Tests/BotTests/GitHub/GitHubEventsTests.swift
@@ -108,9 +108,9 @@ extension GitHubEventsTests {
     }
 
     private func perform(
-        stub: (TestScheduler) -> GitHubService = stubService,
-        when: (GitHubService, TestScheduler) -> Result<Void, GitHubService.EventHandlingError>?,
-        assert: (Result<Void, GitHubService.EventHandlingError>?, [Event]) -> Void
+        stub: (TestScheduler) -> GitHubEventsService = stubService,
+        when: (GitHubEventsService, TestScheduler) -> Result<Void, GitHubEventsService.EventHandlingError>?,
+        assert: (Result<Void, GitHubEventsService.EventHandlingError>?, [Event]) -> Void
     ) {
 
         let scheduler = TestScheduler()
@@ -130,11 +130,11 @@ extension GitHubEventsTests {
         assert(result, observedEvents)
     }
 
-    private static func stubService(_ scheduler: TestScheduler) -> GitHubService {
-        return GitHubService(signatureToken: signatureToken, scheduler: scheduler)
+    private static func stubService(_ scheduler: TestScheduler) -> GitHubEventsService {
+        return GitHubEventsService(signatureToken: signatureToken, scheduler: scheduler)
     }
 
-    private func request(with event: GitHubService.APIEvent, signature: String, payload: String) -> StubbedRequest {
+    private func request(with event: GitHubEventsService.APIEvent, signature: String, payload: String) -> StubbedRequest {
         return request(with: event, signature: signature, payload: payload.data(using: .utf8))
     }
 
@@ -142,15 +142,15 @@ extension GitHubEventsTests {
         return request(withRawEvent: rawEvent, signature: signature, payload: payload.data(using: .utf8))
     }
 
-    private func request(with event: GitHubService.APIEvent, signature: String, payload: Data?) -> StubbedRequest {
+    private func request(with event: GitHubEventsService.APIEvent, signature: String, payload: Data?) -> StubbedRequest {
         return request(withRawEvent: event.rawValue, signature: signature, payload: payload)
     }
 
     private func request(withRawEvent rawEvent: String, signature: String, payload: Data?) -> StubbedRequest {
         return StubbedRequest(
             headers: [
-                GitHubService.HTTPHeader.event.rawValue: rawEvent,
-                GitHubService.HTTPHeader.signature.rawValue: "sha1=\(signature)"
+                GitHubEventsService.HTTPHeader.event.rawValue: rawEvent,
+                GitHubEventsService.HTTPHeader.signature.rawValue: "sha1=\(signature)"
             ],
             data: payload
         )

--- a/Tests/BotTests/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeServiceTests.swift
@@ -781,8 +781,8 @@ class MergeServiceTests: XCTestCase {
         ) {
 
         let scheduler = TestScheduler()
-        let github2 = MockGitHubAPI(stubs: stubs)
-        let service = MergeService(integrationLabel: integrationLabel, logger: MockLogger(), github: github2, scheduler: scheduler)
+        let gitHub = MockGitHubAPI(stubs: stubs)
+        let service = MergeService(integrationLabel: integrationLabel, logger: MockLogger(), gitHubAPI: gitHub, scheduler: scheduler)
 
         var states: [MergeService.State] = []
 
@@ -791,14 +791,14 @@ class MergeServiceTests: XCTestCase {
         when(service, scheduler)
         assert(states)
 
-        expect(github2.assert()) == true
+        expect(gitHub.assert()) == true
     }
 
     private func makeState(
         status: MergeService.State.Status,
         pullRequests: [PullRequest],
         statusChecksTimeout: TimeInterval = defaultStatusChecksTimeout
-        ) -> MergeService.State {
+    ) -> MergeService.State {
         return MergeService.State(
             integrationLabel: integrationLabel,
             statusChecksTimeout: statusChecksTimeout,

--- a/Tests/BotTests/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeServiceTests.swift
@@ -180,7 +180,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
@@ -220,7 +220,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
@@ -308,7 +308,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
@@ -420,7 +420,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
@@ -471,12 +471,12 @@ class MergeServiceTests: XCTestCase {
                 for _ in 1...3 {
 
                     service.statusChecksDidChange(
-                        change: StatusChange(
+                        change: StatusEvent(
                             sha: "abcdef",
                             context: "",
                             description: "N/A",
                             state: .success,
-                            branches: [StatusChange.Branch(name: defaultBranch)]
+                            branches: [StatusEvent.Branch(name: defaultBranch)]
                         )
                     )
 
@@ -618,7 +618,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
@@ -722,7 +722,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
@@ -742,7 +742,7 @@ class MergeServiceTests: XCTestCase {
                 // Simulate all checks being successful
 
                 service.statusChecksDidChange(
-                    change: StatusChange(
+                    change: StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",

--- a/Tests/BotTests/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeServiceTests.swift
@@ -175,19 +175,21 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .success,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -219,15 +221,15 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .success,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 scheduler.advance()
             },
@@ -259,7 +261,9 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance()
-                service.pullRequestDidChange(metadata: targetLabeled, action: .labeled)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .labeled, pullRequestMetadata: targetLabeled))
+                )
                 scheduler.advance()
             },
             assert: {
@@ -299,23 +303,27 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: first.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: first.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: second, action: .labeled)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .labeled, pullRequestMetadata: second))
+                )
 
                 scheduler.advance()
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .success,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -347,11 +355,15 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget, action: .closed)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .closed, pullRequestMetadata: defaultTarget))
+                )
 
                 scheduler.advance()
             },
@@ -379,11 +391,15 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(labels: []), action: .unlabeled)
+                service.eventsObserver.send(value:
+                    .pullRequest(.init(action: .unlabeled, pullRequestMetadata: defaultTarget.with(labels: [])))
+                )
 
                 scheduler.advance()
             },
@@ -415,19 +431,21 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .failure,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -464,21 +482,23 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
                 for _ in 1...3 {
 
-                    service.statusChecksDidChange(
-                        change: StatusEvent(
+                    service.eventsObserver.send(value: .status(
+                        StatusEvent(
                             sha: "abcdef",
                             context: "",
                             description: "N/A",
                             state: .success,
                             branches: [StatusEvent.Branch(name: defaultBranch)]
                         )
-                    )
+                    ))
 
                     scheduler.advance(by: .seconds(60))
                 }
@@ -511,7 +531,9 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value:
+                    .pullRequest(.init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 // 1.5 ensures we trigger the timeout
                 scheduler.advance(by: .minutes(1.5 * defaultStatusChecksTimeout))
@@ -609,23 +631,27 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: first.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value:
+                    .pullRequest(.init(action: .synchronize, pullRequestMetadata: first.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: second.with(labels: []), action: .unlabeled)
+                service.eventsObserver.send(value:
+                    .pullRequest(.init(action: .unlabeled, pullRequestMetadata: second.with(labels: [])))
+                )
 
                 scheduler.advance()
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .failure,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -717,19 +743,21 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.pullRequestDidChange(metadata: defaultTarget.with(mergeState: .blocked), action: .synchronize)
+                service.eventsObserver.send(value: .pullRequest(
+                    .init(action: .synchronize, pullRequestMetadata: defaultTarget.with(mergeState: .blocked)))
+                )
 
                 scheduler.advance()
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .success,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 scheduler.advance(by: .seconds(30))
 
@@ -741,15 +769,15 @@ class MergeServiceTests: XCTestCase {
 
                 // Simulate all checks being successful
 
-                service.statusChecksDidChange(
-                    change: StatusEvent(
+                service.eventsObserver.send(value: .status(
+                    StatusEvent(
                         sha: "abcdef",
                         context: "",
                         description: "N/A",
                         state: .success,
                         branches: [.init(name: defaultBranch)]
                     )
-                )
+                ))
 
                 expectedPullRequest = defaultTarget.with(mergeState: .clean)
                 expectedCommitStatus = CommitState(state: .success, statuses: [])
@@ -774,24 +802,41 @@ class MergeServiceTests: XCTestCase {
 
     // MARK: - Helpers
 
+    struct MockGitHubEventsService: GitHubEventsServiceProtocol {
+        let eventsObserver: Signal<Event, NoError>.Observer
+        let events: Signal<Event, NoError>
+
+        init() {
+            (events, eventsObserver) = Signal.pipe()
+        }
+    }
+
     private func perform(
         stubs: [MockGitHubAPI.Stubs],
-        when: (MergeService, TestScheduler) -> Void,
+        when: (MockGitHubEventsService, TestScheduler) -> Void,
         assert: ([MergeService.State]) -> Void
         ) {
 
         let scheduler = TestScheduler()
-        let gitHub = MockGitHubAPI(stubs: stubs)
-        let service = MergeService(integrationLabel: integrationLabel, logger: MockLogger(), gitHubAPI: gitHub, scheduler: scheduler)
+        let gitHubAPI = MockGitHubAPI(stubs: stubs)
+        let gitHubEvents = MockGitHubEventsService()
+
+        let service = MergeService(
+            integrationLabel: integrationLabel,
+            logger: MockLogger(),
+            gitHubAPI: gitHubAPI,
+            gitHubEvents: gitHubEvents,
+            scheduler: scheduler
+        )
 
         var states: [MergeService.State] = []
 
         service.state.producer.observe(on: scheduler).startWithValues { states.append($0) }
 
-        when(service, scheduler)
+        when(gitHubEvents, scheduler)
         assert(states)
 
-        expect(gitHub.assert()) == true
+        expect(gitHubAPI.assert()) == true
     }
 
     private func makeState(


### PR DESCRIPTION
### Description

This includes the integration of `GitHubEventsService` in `MergeService` to start consuming all events and handle any pull requests labelled to be merged.

The remaining configuration needed was also included and should be configured as environment variables.

- `GITHUB_TOKEN`: GitHub API Token
- `GITHUB_ORGANIZATION`: the name of the organization where the targeted repository is hosted
- `GITHUB_REPOSITORY`: the name of the targeted repository
- `MERGE_LABEL`: the name of the label used to flag pull requests needed to be merged
