### PR TITLE
Fix wrong path while merging a pull request

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -4,9 +4,6 @@ import Vapor
 public func routes(_ router: Router, logger: LoggerProtocol, gitHubEventsService: GitHubEventsService) throws {
 
     router.post("github") { request -> HTTPResponse in
-
-        logger.log("📨 handling event: \(request)")
-
         switch gitHubEventsService.handleEvent(from: request).first() {
         case .success?:
             return HTTPResponse(status: .ok)

--- a/Sources/Bot/API/Repository.swift
+++ b/Sources/Bot/API/Repository.swift
@@ -96,7 +96,7 @@ extension Repository {
     func merge(pullRequest: PullRequest) -> Resource<Void> {
         return Resource(
             method: .PUT,
-            path: "pulls/\(pullRequest.number)/merge",
+            path: path(for: "pulls/\(pullRequest.number)/merge"),
             body: encode(MergePullRequestRequest(with: pullRequest)),
             decoder: decode
         )


### PR DESCRIPTION
### Description

Our testing revealed this issue which needs to be fixed. We probably need to rethink the strategy to ensure all paths for a certain repository are correctly prefixed as the current system cannot guarantee that.

This also removes a log message which is too verbose at this point.