### PR TITLE
Fix merge of branches

### DIFF
--- a/Sources/Bot/API/Repository.swift
+++ b/Sources/Bot/API/Repository.swift
@@ -83,7 +83,7 @@ extension Repository {
             body: encode(MergeBranchRequest(base: base, head: head)),
             decoder: { response in
                 switch response.statusCode {
-                case 200: return .success(.success)
+                case 201: return .success(.success)
                 case 204: return .success(.upToDate)
                 case 409: return .success(.conflict)
                 default:

--- a/Sources/Bot/Models/PullRequest.swift
+++ b/Sources/Bot/Models/PullRequest.swift
@@ -58,3 +58,15 @@ extension PullRequest: Decodable {
         case labels
     }
 }
+
+extension PullRequest: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "PR(#\(number), base: \(target), head: \"\(source)\")"
+    }
+}
+
+extension PullRequest.Branch: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "Branch(\(ref), \(sha))"
+    }
+}

--- a/Sources/Bot/Models/PullRequestMetadata.swift
+++ b/Sources/Bot/Models/PullRequestMetadata.swift
@@ -43,3 +43,9 @@ extension PullRequestMetadata: Decodable {
         case mergeState = "mergeable_state"
     }
 }
+
+extension PullRequestMetadata: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        return "\(reference), isMerged: \(isMerged), mergeState: \(mergeState))"
+    }
+}

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -615,8 +615,20 @@ private extension PullRequest {
 
 extension MergeService.State: CustomDebugStringConvertible {
 
+    private var queueDescription: String {
+        guard pullRequests.isEmpty == false else { return "[]" }
+
+        let pullRequestsSeparator = "\n\t\t"
+
+        let pullRequestsRepresentation = pullRequests.enumerated().map { index, pullRequest in
+            return "#\(index + 1): \(pullRequest)"
+        }.joined(separator: pullRequestsSeparator)
+
+        return "\(pullRequestsSeparator)\(pullRequestsRepresentation)"
+    }
+
     var debugDescription: String {
-        return "State(\(status), pullRequests: \(pullRequests))"
+        return "State(\n - status: \(status),\n - queue: \(queueDescription)\n)"
     }
 }
 
@@ -636,4 +648,3 @@ extension Int {
         return Double(self) * 60
     }
 }
-

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -55,6 +55,7 @@ public final class MergeService {
             }
 
         gitHubEvents.events
+            .observe(on: scheduler)
             .observeValues { [weak self] event in
                 switch event {
                 case let .pullRequest(event):

--- a/Tests/BotTests/GitHub/GitHubAPITests.swift
+++ b/Tests/BotTests/GitHub/GitHubAPITests.swift
@@ -170,7 +170,7 @@ class GitHubAPITests: XCTestCase {
                     Interceptor.Stub(
                         response: Interceptor.Stub.Response(
                             url: URL(string: "https://api.github.com/repos/golang/go/merges")!,
-                            statusCode: 200,
+                            statusCode: 201,
                             body: Data()
                         )
                     )]


### PR DESCRIPTION
### Description

Merging branches were wrongly expecting a status code of 200 instead of 201 as documented by [GitHub](https://developer.github.com/v3/repos/merging/). This corrects that typo.

There's some improvements in terms of logging by conforming to `CustomDebugStringConvertible`.

```
♻️ [Merge Service] Did change state
 - 📜 State(
 - status: ready,
 - queue: 
      #1: PR(#144, base: Branch(master, abc), head: "Branch(abcdef, abcdef)")
      #2: PR(#233, base: Branch(master, abc), head: "Branch(abcdef, abcdef)")
      #3: PR(#377, base: Branch(master, abc), head: "Branch(abcdef, abcdef)")
) 
 - 📄 State(
 - status: integrating(PR(#144, base: Branch(master, abc), head: "Branch(abcdef, abcdef)"), isMerged: false, mergeState: clean)),
 - queue: 
      #1: PR(#233, base: Branch(master, abc), head: "Branch(abcdef, abcdef)")
      #2: PR(#377, base: Branch(master, abc), head: "Branch(abcdef, abcdef)")
)
```