### PR TITLE
Fix wrong reporting while adding pull requests

### DIFF
--- a/Tests/BotTests/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeServiceTests.swift
@@ -290,7 +290,10 @@ class MergeServiceTests: XCTestCase {
                 .getPullRequest { _ in first },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
-                .postComment { _, _ in },
+                .postComment { message, pullRequest in
+                    expect(message) == "Your pull request was accepted and it's currently `#1` in the queue, hold tight ⏳"
+                    expect(pullRequest.number) == 2
+                },
                 .getPullRequest { _ in first.with(mergeState: .clean) },
                 .getCommitStatus { _ in CommitState(state: .success, statuses: []) },
                 .mergePullRequest { _ in },


### PR DESCRIPTION
### Description

The reporting that informs the position of the pull request in the queue was not taking in consideration if we have a pull request being integrated already, which means it won't be in the queue anymore, and in the cases where the queue it's empty we were considering the new pull request as the next one to be picked up immediately instead of reporting as the 1st in the queue.

There's a test that checks for this behaviour in specific.

#### Observed behaviour
```
- Status: integrating PR
- Queue: []

Effect ▶️ Adding new PR

*Report*: `Your pull request was accepted and is going to be handled right away 🏎`
```

#### Expected behaviour
```
- Status: integrating PR
- Queue: []

Effect ▶️ Adding new PR

*Report*: `Your pull request was accepted and it's currently `#1` in the queue, hold tight ⏳`
```
