### PR TITLE
[IOSP-177] Define a healthcheck route to access the health of the bot

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -17,11 +17,13 @@ public func configure(_ config: inout Config, _ env: inout Environment, _ servic
 
     logger.log("👟 Starting up...")
 
-    services.register(try makeMergeService(with: logger, gitHubEventsService))
+    let mergeService = try makeMergeService(with: logger, gitHubEventsService)
+
+    services.register(mergeService)
 
     // Register routes to the router
     let router = EngineRouter.default()
-    try routes(router, logger: logger, gitHubEventsService: gitHubEventsService)
+    try routes(router, logger: logger, mergeService: mergeService, gitHubEventsService: gitHubEventsService)
     services.register(router, as: Router.self)
 
     // Register middleware

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,7 +1,19 @@
 import Bot
 import Vapor
 
-public func routes(_ router: Router, logger: LoggerProtocol, gitHubEventsService: GitHubEventsService) throws {
+public func routes(
+    _ router: Router,
+    logger: LoggerProtocol,
+    mergeService: MergeService,
+    gitHubEventsService: GitHubEventsService
+) throws {
+
+    router.get("healthcheck") { request -> HTTPResponse in
+        switch mergeService.healthcheck.status.value {
+        case .ok: return HTTPResponse(status: .ok)
+        default: return HTTPResponse(status: .serviceUnavailable)
+        }
+    }
 
     router.post("github") { request -> HTTPResponse in
         switch gitHubEventsService.handleEvent(from: request).first() {

--- a/Tests/BotTests/MergeServiceHealthcheckTests.swift
+++ b/Tests/BotTests/MergeServiceHealthcheckTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+import Nimble
+import ReactiveSwift
+import Result
+@testable import Bot
+
+class MergeServiceHealthcheckTests: XCTestCase {
+
+    private let statusChecksTimeout = 30.minutes
+
+    func test_healthcheck_passing() {
+
+        perform(
+            when: { input, scheduler in
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .starting))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .idle))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .ready))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .integrating(defaultTarget)))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .ready))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .idle))
+
+                scheduler.advance()
+            },
+            assert: { statuses in
+                expect(statuses) == [.ok, .ok, .ok]
+            }
+        )
+    }
+
+    func test_healthcheck_failing() {
+
+        perform(
+            when: { input, scheduler in
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .starting))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .idle))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .ready))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .runningStatusChecks(defaultTarget)))
+
+                scheduler.advance(by: .minutes(2 * defaultStatusChecksTimeout))
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .integrationFailed(defaultTarget, .checksFailing)))
+
+                scheduler.advance()
+
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .ready))
+                input.send(value: .init(integrationLabel: .init(name: "Merge"), statusChecksTimeout: statusChecksTimeout, pullRequests: [], status: .idle))
+
+                scheduler.advance()
+
+            },
+            assert: { statuses in
+                expect(statuses) == [.ok, .ok, .unhealthy(.potentialDeadlock), .ok]
+            }
+        )
+    }
+
+    private func perform(
+        when: (Signal<MergeService.State, NoError>.Observer, TestScheduler) -> Void,
+        assert: ([MergeService.Healthcheck.Status]) -> Void
+    ) {
+        let state = Signal<MergeService.State, NoError>.pipe()
+        let scheduler = TestScheduler()
+
+        var statuses: [MergeService.Healthcheck.Status] = []
+
+        let healthcheck = MergeService.Healthcheck(
+            state: state.output,
+            statusChecksTimeout: statusChecksTimeout,
+            scheduler: scheduler
+        )
+
+        healthcheck.status.producer.startWithValues { status in
+            statuses.append(status)
+        }
+
+        when(state.input, scheduler)
+        assert(statuses)
+    }
+}


### PR DESCRIPTION
To deploy Wall-E we need a healthcheck route to assess the health of the service. However, this can be particularly tricky to do because all network activity is signed so we cannot use a `ping` event for example.

Based on that, we are monitoring the internal state of `MergeService` to monitor if the state keeps changing, meaning there's activity and PRs are being picked up and merged until it finally changes back to `idle`. This can be done with the concept of timeouts, because we have a specific time window to handle a PR, based on `statusChecksTimeout`, we can estimate that by then the state should have changed already if it haven't means there's something wrong and unexpected. This system is not super strong but it's a bit hard to monitor this concept.