### PR TITLE
Add a docker image to run Wall-E as a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM swift:4.2
+
+WORKDIR /Wall-E
+COPY . /Wall-E
+
+RUN swift build -c release
+
+EXPOSE 2008
+
+CMD ./.build/release/Run --env production --hostname 0.0.0.0 --port 2008


### PR DESCRIPTION
This is a base image to run Wall-E as a container. The image itself still needs to be deployed and hosted in either Docker Hub or [quay.io](https://quay.io).