### PR TITLE
[IOSP-178] Ensure tags deploy the docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,25 @@
 version: 2.1
 
 references:
+  - &enable_tags
+    filters:
+      tags:
+        only: 
+          - /.*/
   - &only_tagged
     filters:
       branches:
         ignore:
-        - /^.*$/
+        - /.*/
       tags:
         only:
-        - /^.*$/
+        - /.*/
 
 commands:
   quay_login:
     steps:
       - run: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}" quay.io
-    
+
 
 jobs:
   test:
@@ -49,14 +54,17 @@ jobs:
 
 workflows:
   version: 2
+
   test-build-deploy:
     jobs:
       - test:
           context: babylon
+          <<: *enable_tags
       - build:
           context: babylon
           requires: [test]
+          <<: *enable_tags
       - deploy:
           context: babylon
-          <<: *only_tagged
           requires: [build]
+          <<: *only_tagged

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  - &on_branchs_and_tags
+  - &on_branches_and_tags
     filters:
       tags:
         only: 
@@ -59,11 +59,11 @@ workflows:
     jobs:
       - test:
           context: babylon
-          <<: *on_branchs_and_tags
+          <<: *on_branches_and_tags
       - build:
           context: babylon
           requires: [test]
-          <<: *on_branchs_and_tags
+          <<: *on_branches_and_tags
       - deploy:
           context: babylon
           requires: [build]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 references:
-  - &enable_tags
+  - &on_branchs_and_tags
     filters:
       tags:
         only: 
           - /.*/
-  - &only_tagged
+  - &on_tags_only
     filters:
       branches:
         ignore:
@@ -59,12 +59,12 @@ workflows:
     jobs:
       - test:
           context: babylon
-          <<: *enable_tags
+          <<: *on_branchs_and_tags
       - build:
           context: babylon
           requires: [test]
-          <<: *enable_tags
+          <<: *on_branchs_and_tags
       - deploy:
           context: babylon
           requires: [build]
-          <<: *only_tagged
+          <<: *on_tags_only


### PR DESCRIPTION
The previous logic was faulty as tags are not enabled by default and they need to be enabled on each job part of the workflow.