### PR TITLE
[IOSP-196] Include config to only consider *required* checks to merge

### DIFF
--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -19,6 +19,13 @@ extension Environment {
         return try Environment.get("GITHUB_REPOSITORY")
     }
 
+    static func requiresAllGitHubStatusChecks() throws -> Bool {
+        guard let stringValue: String = try? Environment.get("REQUIRES_ALL_STATUS_CHECKS") else {
+            return false // defaults to only consider required checks
+        }
+        return ["yes", "1", "true"].contains(stringValue.lowercased())
+    }
+
     static func mergeLabel() throws -> PullRequest.Label {
         return PullRequest.Label(name: try Environment.get("MERGE_LABEL"))
     }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -43,6 +43,7 @@ private func makeMergeService(with logger: LoggerProtocol, _ gitHubEventsService
     return MergeService(
         integrationLabel: try Environment.mergeLabel(),
         topPriorityLabels: try Environment.topPriorityLabels(),
+        requiresAllStatusChecks: try Environment.requiresAllGitHubStatusChecks(), 
         logger: logger,
         gitHubAPI: gitHubAPI,
         gitHubEvents: gitHubEventsService,

--- a/Sources/Bot/API/GitHubAPIProtocol.swift
+++ b/Sources/Bot/API/GitHubAPIProtocol.swift
@@ -10,6 +10,8 @@ public protocol GitHubAPIProtocol {
 
     func fetchCommitStatus(for pullRequest: PullRequest) -> SignalProducer<CommitState, AnyError>
 
+    func fetchRequiredStatusChecks(for branch: PullRequest.Branch) -> SignalProducer<RequiredStatusChecks, AnyError>
+
     /// Merges one branch into another.
     ///
     /// - SeeAlso: https://developer.github.com/v3/repos/merging/

--- a/Sources/Bot/API/Repository.swift
+++ b/Sources/Bot/API/Repository.swift
@@ -51,6 +51,14 @@ extension Repository {
         )
     }
 
+    func requiredStatusChecks(branch: PullRequest.Branch) -> Resource<RequiredStatusChecks> {
+        return Resource(
+            method: .GET,
+            path: path(for: "branches/\(branch.ref)/protection/required_status_checks"),
+            decoder: decode
+        )
+    }
+
     func deleteBranch(branch: PullRequest.Branch) -> Resource<Void> {
         return Resource(
             method: .DELETE,

--- a/Sources/Bot/API/RepositoryAPI.swift
+++ b/Sources/Bot/API/RepositoryAPI.swift
@@ -29,6 +29,11 @@ public struct RepositoryAPI: GitHubAPIProtocol {
             .mapError(AnyError.init)
     }
 
+    public func fetchRequiredStatusChecks(for branch: PullRequest.Branch) -> SignalProducer<RequiredStatusChecks, AnyError> {
+        return client.request(repository.requiredStatusChecks(branch: branch))
+            .mapError(AnyError.init)
+    }
+
     public func merge(head: PullRequest.Branch, into base: PullRequest.Branch) -> SignalProducer<MergeResult, AnyError> {
         return client.request(repository.merge(head: head, into: base))
             .mapError(AnyError.init)

--- a/Sources/Bot/Models/CommitState.swift
+++ b/Sources/Bot/Models/CommitState.swift
@@ -14,12 +14,38 @@ public struct CommitState: Decodable, Equatable {
         public let context: String
     }
 
-    /// Combined state for all the checks
-    /// - `.failure` if any of the contexts report as error or failure
-    /// - `.pending` if there are no statuses or a context is pending
-    /// - `.success` if the latest status for all contexts is success
+    /// Combined state for _all_ the checks
+    /// - `.failure` if any of the status checks (`statuses.map(\.state)`) reports an error or `.failure`
+    /// - `.pending` if there are no statuses, or a status check is `.pending`
+    /// - `.success` if the latest status for all checks is `.success`
+    /// See https://developer.github.com/v3/repos/statuses/#get-the-combined-status-for-a-specific-ref
     public let state: State
 
     /// Individual status of each check
     public let statuses: [Status]
+}
+
+
+extension CommitState.State {
+
+    /// Compute the combined state for a set of states.
+    /// This logic replicates the behavior provided by the GitHub API (see `CommitState.state` property provided by GitHub API above)
+    ///
+    /// We use this method ourselves to:
+    ///  - compute a similar combined state as GitHub API provides, but for only a subset of checks (especially only considering _required_ checks)
+    ///  - create stubs for `CommitState` in the tests to replicate the GitHub API behavior
+    /// - Parameter states: List of states to compute the combined state for
+    /// - Returns
+    ///   - `.failure` if any of the status checks reports a `.failure`
+    ///   - `.pending` if there are no statuses, or a status check is `.pending`
+    ///   - `.success` if the latest status for all checks is `.success`
+    static func combinedState(for states: [CommitState.State]) -> CommitState.State {
+        if states.contains(.failure) {
+            return .failure
+        } else if states.contains(.pending) {
+            return .pending
+        } else {
+            return .success
+        }
+    }
 }

--- a/Sources/Bot/Models/CommitState.swift
+++ b/Sources/Bot/Models/CommitState.swift
@@ -14,6 +14,12 @@ public struct CommitState: Decodable, Equatable {
         public let context: String
     }
 
+    /// Combined state for all the checks
+    /// - `.failure` if any of the contexts report as error or failure
+    /// - `.pending` if there are no statuses or a context is pending
+    /// - `.success` if the latest status for all contexts is success
     public let state: State
+
+    /// Individual status of each check
     public let statuses: [Status]
 }

--- a/Sources/Bot/Models/RequiredStatusCheck.swift
+++ b/Sources/Bot/Models/RequiredStatusCheck.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public struct RequiredStatusChecks: Decodable, Equatable {
+    public let strict: Bool // Require branches to be up to date before merging?
+    public let contexts: [String] // Names of status checks marked as Required
+}

--- a/Sources/Bot/Models/RequiredStatusCheck.swift
+++ b/Sources/Bot/Models/RequiredStatusCheck.swift
@@ -2,7 +2,12 @@ import Foundation
 
 public struct RequiredStatusChecks: Decodable, Equatable {
     /// Require branches to be up to date before merging?
-    public let strict: Bool
+    public let isStrict: Bool
     /// Names of status checks marked as Required
     public let contexts: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case isStrict = "strict"
+        case contexts
+    }
 }

--- a/Sources/Bot/Models/RequiredStatusCheck.swift
+++ b/Sources/Bot/Models/RequiredStatusCheck.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public struct RequiredStatusChecks: Decodable, Equatable {
-    public let strict: Bool // Require branches to be up to date before merging?
-    public let contexts: [String] // Names of status checks marked as Required
+    /// Require branches to be up to date before merging?
+    public let strict: Bool
+    /// Names of status checks marked as Required
+    public let contexts: [String]
 }

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -417,8 +417,15 @@ extension MergeService {
         }
     }
 
-    fileprivate static func getRequiredChecksState(github: GitHubAPIProtocol, targetBranch: PullRequest.Branch, commitState: CommitState) -> SignalProducer<CommitState.State, AnyError> {
-        github.fetchRequiredStatusChecks(for: targetBranch).map { (requiredStatusChecks) -> CommitState.State in
+    fileprivate static func getRequiredChecksState(
+        github: GitHubAPIProtocol,
+        targetBranch: PullRequest.Branch,
+        commitState: CommitState
+    ) -> SignalProducer<CommitState.State, AnyError> {
+        guard commitState.state != .success else {
+            return .value(.success)
+        }
+        return github.fetchRequiredStatusChecks(for: targetBranch).map { (requiredStatusChecks) -> CommitState.State in
             let requiredStates = commitState.statuses.filter { status in
                 requiredStatusChecks.contexts.contains(status.context)
             }

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -21,6 +21,7 @@ public final class MergeService {
     public init(
         integrationLabel: PullRequest.Label,
         topPriorityLabels: [PullRequest.Label],
+        requiresAllStatusChecks: Bool,
         statusChecksTimeout: TimeInterval = 60.minutes,
         logger: LoggerProtocol,
         gitHubAPI: GitHubAPIProtocol,
@@ -43,8 +44,8 @@ public final class MergeService {
             feedbacks: [
                 Feedbacks.whenStarting(github: self.gitHubAPI, scheduler: scheduler),
                 Feedbacks.whenReady(github: self.gitHubAPI, scheduler: scheduler),
-                Feedbacks.whenIntegrating(github: self.gitHubAPI, pullRequestChanges: pullRequestChanges, scheduler: scheduler),
-                Feedbacks.whenRunningStatusChecks(github: self.gitHubAPI, logger: logger, statusChecksCompletion: statusChecksCompletion, scheduler: scheduler),
+                Feedbacks.whenIntegrating(github: self.gitHubAPI, requiresAllStatusChecks: requiresAllStatusChecks, pullRequestChanges: pullRequestChanges, scheduler: scheduler),
+                Feedbacks.whenRunningStatusChecks(github: self.gitHubAPI, logger: logger, requiresAllStatusChecks: requiresAllStatusChecks, statusChecksCompletion: statusChecksCompletion, scheduler: scheduler),
                 Feedbacks.whenIntegrationFailed(github: self.gitHubAPI, logger: logger, scheduler: scheduler),
                 Feedbacks.pullRequestChanges(pullRequestChanges: pullRequestChanges, scheduler: scheduler),
                 Feedbacks.whenAddingPullRequests(github: self.gitHubAPI, scheduler: scheduler)
@@ -175,6 +176,7 @@ extension MergeService {
 
     fileprivate static func whenIntegrating(
         github: GitHubAPIProtocol,
+        requiresAllStatusChecks: Bool,
         pullRequestChanges: Signal<(PullRequestMetadata, PullRequest.Action), NoError>,
         scheduler: DateScheduler
     ) -> Feedback<State, Event> {
@@ -229,12 +231,17 @@ extension MergeService {
             case .blocked,
                  .unstable:
                 return github.fetchCommitStatus(for: metadata.reference)
-                    .flatMap(.latest) { commitStatus -> SignalProducer<Event, AnyError> in
-                        switch commitStatus.state {
+                    .flatMap(.latest) { (commitStatus: CommitState) -> SignalProducer<CommitState.State, AnyError> in
+                        return requiresAllStatusChecks
+                            ? .value(commitStatus.state)
+                            : getRequiredChecksState(github: github, targetBranch: metadata.reference.target, commitState: commitStatus)
+                    }
+                    .flatMap(.latest) { state -> SignalProducer<Event, AnyError> in
+                        switch state {
                         case .pending:
                             return .value(.integrationDidChangeStatus(.updating, metadata))
                         case .failure:
-                            return .value(.integrationDidChangeStatus(.failed(.checkingCommitChecksFailed), metadata))
+                            return .value(.integrationDidChangeStatus(.failed(.checksFailing), metadata))
                         case  .success:
                             return github.fetchPullRequest(number: metadata.reference.number)
                                 .map { metadata in
@@ -280,6 +287,7 @@ extension MergeService {
     fileprivate static func whenRunningStatusChecks(
         github: GitHubAPIProtocol,
         logger: LoggerProtocol,
+        requiresAllStatusChecks: Bool,
         statusChecksCompletion: Signal<StatusEvent, NoError>,
         scheduler: DateScheduler
     ) -> Feedback<State, Event> {
@@ -315,13 +323,19 @@ extension MergeService {
                 // window where all checks have passed but just until the next check is added and stars running. This
                 // hopefully prevents those false positives by making sure we wait some time before checking if all
                 // checks have passed
-                .debounce(60, on: scheduler)
+                .debounce(60.0, on: scheduler)
                 .flatMap(.latest) { change in
                     github.fetchPullRequest(number: pullRequest.number)
                         .flatMap(.latest) { github.fetchCommitStatus(for: $0.reference).zip(with: .value($0)) }
+                        .flatMap(.latest) { commitStatus, pullRequestMetadataRefreshed -> SignalProducer<(CommitState.State, PullRequestMetadata), AnyError> in
+                            let requiredStateProducer = requiresAllStatusChecks
+                                ? .value(commitStatus.state)
+                                : getRequiredChecksState(github: github, targetBranch: pullRequest.target, commitState: commitStatus)
+                            return requiredStateProducer.zip(with: .value(pullRequestMetadataRefreshed))
+                        }
                         .flatMapError { _ in .empty }
-                        .filterMap { commitStatus, pullRequestMetadataRefreshed in
-                            switch commitStatus.state {
+                        .filterMap { state, pullRequestMetadataRefreshed in
+                            switch state {
                             case .pending:
                                 return nil
                             case .failure:
@@ -400,6 +414,21 @@ extension MergeService {
                 }
                 .skipNil()
                 .map(Event.pullRequestDidChange)
+        }
+    }
+
+    fileprivate static func getRequiredChecksState(github: GitHubAPIProtocol, targetBranch: PullRequest.Branch, commitState: CommitState) -> SignalProducer<CommitState.State, AnyError> {
+        github.fetchRequiredStatusChecks(for: targetBranch).map { (requiredStatusChecks) -> CommitState.State in
+            let requiredStates = commitState.statuses.filter { status in
+                requiredStatusChecks.contexts.contains(status.context)
+            }
+            if requiredStates.contains(where: { status in status.state == .pending }) {
+                return .pending
+            } else if requiredStates.contains(where: { status in status.state == .failure }) {
+                return .failure
+            } else {
+                return .success
+            }
         }
     }
 }

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -428,13 +428,7 @@ extension MergeService {
             let requiredStates = requiredStatusChecks.contexts.map { requiredContext in
                 commitState.statuses.first(where: { $0.context == requiredContext })?.state ?? .pending
             }
-            if requiredStates.contains(.failure) {
-                return .failure
-            } else if requiredStates.contains(.pending) {
-                return .pending
-            } else {
-                return .success
-            }
+            return CommitState.State.combinedState(for: requiredStates)
         }
     }
 }

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -232,8 +232,8 @@ extension MergeService {
             case .blocked,
                  .unstable:
                 return github.fetchCommitStatus(for: metadata.reference)
-                    .flatMap(.latest) { status -> SignalProducer<Event, AnyError> in
-                        switch status.state {
+                    .flatMap(.latest) { commitStatus -> SignalProducer<Event, AnyError> in
+                        switch commitStatus.state {
                         case .pending:
                             return .value(.integrationDidChangeStatus(.updating, metadata))
                         case .failure:
@@ -413,6 +413,9 @@ extension MergeService {
         }
     }
 
+    /// Returns the consolidated status of all _required_ checks only
+    /// i.e. returns .failure or .pending if one of the required check is in .failure or .pending respectively
+    /// and return .success only if all required states are .success
     fileprivate static func getRequiredChecksState(
         github: GitHubAPIProtocol,
         targetBranch: PullRequest.Branch,

--- a/Tests/BotTests/Canned Data/GitHubPullRequest.swift
+++ b/Tests/BotTests/Canned Data/GitHubPullRequest.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 let GitHubPullRequest = """
 {
     "id": 1,

--- a/Tests/BotTests/Canned Data/GitHubPullRequestEvent.swift
+++ b/Tests/BotTests/Canned Data/GitHubPullRequestEvent.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 let GitHubPullRequestEvent: String = """
 {
     "action": "closed",

--- a/Tests/BotTests/Canned Data/GitHubRequiredStatusChecks.swift
+++ b/Tests/BotTests/Canned Data/GitHubRequiredStatusChecks.swift
@@ -1,0 +1,17 @@
+let GitHubRequiredStatusChecks: String = """
+{
+    "url": "https://api.github.com/repos/babylonhealth/babylon-ios/branches/develop/protection/required_status_checks",
+    "strict": true,
+    "contexts": [
+        "ci/circleci: Build: SDK",
+        "ci/circleci: UnitTests: Ascension",
+        "ci/circleci: UnitTests: BabylonKSA",
+        "ci/circleci: UnitTests: BabylonUS",
+        "ci/circleci: UnitTests: Telus",
+        "ci/circleci: SnapshotTests: BabylonChatBotUI",
+        "ci/circleci: SnapshotTests: BabylonUI",
+        "ci/circleci: SnapshotTests: Babylon"
+    ],
+    "contexts_url": "https://api.github.com/repos/babylonhealth/babylon-ios/branches/develop/protection/required_status_checks/contexts"
+}
+"""

--- a/Tests/BotTests/Canned Data/GitHubStatusEvent.swift
+++ b/Tests/BotTests/Canned Data/GitHubStatusEvent.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 let GitHubStatusEvent: String = """
 {
   "id": 5018968172,

--- a/Tests/BotTests/GitHub/GitHubAPITests.swift
+++ b/Tests/BotTests/GitHub/GitHubAPITests.swift
@@ -113,7 +113,7 @@ class GitHubAPITests: XCTestCase {
 
             expect(result).toNot(beNil())
             expect(result) == RequiredStatusChecks(
-                strict: true,
+                isStrict: true,
                 contexts: [
                     "ci/circleci: Build: SDK",
                     "ci/circleci: UnitTests: Ascension",

--- a/Tests/BotTests/GitHub/GitHubAPITests.swift
+++ b/Tests/BotTests/GitHub/GitHubAPITests.swift
@@ -93,6 +93,41 @@ class GitHubAPITests: XCTestCase {
         }
     }
 
+    func test_fetch_required_status_checks() {
+        perform(stub:
+            Interceptor.load(
+                stubs: [
+                    Interceptor.Stub(
+                        response: Interceptor.Stub.Response(
+                            url: URL(string: "https://api.github.com/repos/babylonhealth/babylon-ios/branches/develop/protection/required_status_checks")!,
+                            statusCode: 200,
+                            body: GitHubRequiredStatusChecks.data(using: .utf8)!
+                        )
+                    )]
+            )
+        ) { client in
+
+            let api = RepositoryAPI(client: client, repository: .init(owner: "golang", name: "go"))
+
+            let result = api.fetchRequiredStatusChecks(for: target.target).first()?.value
+
+            expect(result).toNot(beNil())
+            expect(result) == RequiredStatusChecks(
+                strict: true,
+                contexts: [
+                    "ci/circleci: Build: SDK",
+                    "ci/circleci: UnitTests: Ascension",
+                    "ci/circleci: UnitTests: BabylonKSA",
+                    "ci/circleci: UnitTests: BabylonUS",
+                    "ci/circleci: UnitTests: Telus",
+                    "ci/circleci: SnapshotTests: BabylonChatBotUI",
+                    "ci/circleci: SnapshotTests: BabylonUI",
+                    "ci/circleci: SnapshotTests: Babylon"
+                ]
+            )
+        }
+    }
+
     func test_delete_branch() {
 
         perform(stub:

--- a/Tests/BotTests/MergeService/MergeServiceHealthcheckTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceHealthcheckTests.swift
@@ -12,27 +12,27 @@ class MergeServiceHealthcheckTests: XCTestCase {
             when: { input, scheduler in
                 scheduler.advance()
 
-                input.send(value: makeState(status: .starting))
+                input.send(value: MergeService.State.stub(status: .starting))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .idle))
+                input.send(value: MergeService.State.stub(status: .idle))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .ready))
+                input.send(value: MergeService.State.stub(status: .ready))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .integrating(MergeServiceFixture.defaultTarget)))
+                input.send(value: MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .ready))
+                input.send(value: MergeService.State.stub(status: .ready))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .idle))
+                input.send(value: MergeService.State.stub(status: .idle))
 
                 scheduler.advance()
             },
@@ -49,28 +49,28 @@ class MergeServiceHealthcheckTests: XCTestCase {
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .starting))
+                input.send(value: MergeService.State.stub(status: .starting))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .idle))
+                input.send(value: MergeService.State.stub(status: .idle))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .ready))
+                input.send(value: MergeService.State.stub(status: .ready))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget)))
+                input.send(value: MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget)))
 
                 scheduler.advance(by: .minutes(2 * MergeServiceFixture.defaultStatusChecksTimeout))
 
-                input.send(value: makeState(status: .integrationFailed(MergeServiceFixture.defaultTarget, .checksFailing)))
+                input.send(value: MergeService.State.stub(status: .integrationFailed(MergeServiceFixture.defaultTarget, .checksFailing)))
 
                 scheduler.advance()
 
-                input.send(value: makeState(status: .ready))
-                input.send(value: makeState(status: .idle))
+                input.send(value: MergeService.State.stub(status: .ready))
+                input.send(value: MergeService.State.stub(status: .idle))
 
                 scheduler.advance()
 

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -22,8 +22,8 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -43,8 +43,8 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -65,11 +65,11 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -104,15 +104,15 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: pullRequests.map { $0.reference }),
-                    makeState(status: .integrating(pullRequests[0]), pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
-                    makeState(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
-                    makeState(status: .integrating(pullRequests[1]), pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
-                    makeState(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
-                    makeState(status: .integrating(pullRequests[2])),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }),
+                    MergeService.State.stub(status: .integrating(pullRequests[0]), pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
+                    MergeService.State.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
+                    MergeService.State.stub(status: .integrating(pullRequests[1]), pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
+                    MergeService.State.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
+                    MergeService.State.stub(status: .integrating(pullRequests[2])),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -135,12 +135,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [target.reference]),
-                    makeState(status: .integrating(target)),
-                    makeState(status: .integrationFailed(target, .conflicts)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [target.reference]),
+                    MergeService.State.stub(status: .integrating(target)),
+                    MergeService.State.stub(status: .integrationFailed(target, .conflicts)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -182,13 +182,13 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -222,12 +222,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -255,12 +255,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .idle),
-                    makeState(status: .ready, pullRequests: [targetLabeled.reference]),
-                    makeState(status: .integrating(targetLabeled)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .idle),
+                    MergeService.State.stub(status: .ready, pullRequests: [targetLabeled.reference]),
+                    MergeService.State.stub(status: .integrating(targetLabeled)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
         }
         )
@@ -319,16 +319,16 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [first.reference]),
-                    makeState(status: .integrating(first)),
-                    makeState(status: .runningStatusChecks(first.with(mergeState: .blocked))),
-                    makeState(status: .runningStatusChecks(first.with(mergeState: .blocked)), pullRequests: [second.reference]),
-                    makeState(status: .integrating(first.with(mergeState: .clean)), pullRequests: [second.reference]),
-                    makeState(status: .ready, pullRequests: [second.reference]),
-                    makeState(status: .integrating(second)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [first.reference]),
+                    MergeService.State.stub(status: .integrating(first)),
+                    MergeService.State.stub(status: .runningStatusChecks(first.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .runningStatusChecks(first.with(mergeState: .blocked)), pullRequests: [second.reference]),
+                    MergeService.State.stub(status: .integrating(first.with(mergeState: .clean)), pullRequests: [second.reference]),
+                    MergeService.State.stub(status: .ready, pullRequests: [second.reference]),
+                    MergeService.State.stub(status: .integrating(second)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -359,12 +359,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -395,12 +395,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -441,13 +441,13 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .blocked), .checksFailing)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .blocked), .checksFailing)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -495,13 +495,13 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -530,13 +530,13 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .blocked), .checksFailing)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .blocked), .checksFailing)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -559,12 +559,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .unknown))),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .unknown))),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -589,12 +589,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .unknown))),
-                    makeState(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .unknown), .unknown)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .unknown))),
+                    MergeService.State.stub(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .unknown), .unknown)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -647,14 +647,14 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [first, second].map { $0.reference}),
-                    makeState(status: .integrating(first), pullRequests: [second.reference]),
-                    makeState(status: .runningStatusChecks(first.with(mergeState: .blocked)), pullRequests: [second.reference]),
-                    makeState(status: .runningStatusChecks(first.with(mergeState: .blocked))),
-                    makeState(status: .integrating(first.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [first, second].map { $0.reference}),
+                    MergeService.State.stub(status: .integrating(first), pullRequests: [second.reference]),
+                    MergeService.State.stub(status: .runningStatusChecks(first.with(mergeState: .blocked)), pullRequests: [second.reference]),
+                    MergeService.State.stub(status: .runningStatusChecks(first.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrating(first.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -746,20 +746,20 @@ class MergeServiceTests: XCTestCase {
             assert: {
                 let pr3_tp = pr3.with(labels: [LabelFixture.integrationLabel, LabelFixture.topPriorityLabels[1]])
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [pr2, pr1, pr3, pr4].map{$0.reference}),
-                    makeState(status: .integrating(pr2), pullRequests: [pr1, pr3, pr4].map{$0.reference}),
-                    makeState(status: .integrating(pr2), pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
-                    makeState(status: .runningStatusChecks(pr2.with(mergeState: .blocked)), pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
-                    makeState(status: .integrating(pr2.with(mergeState: .clean)), pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
-                    makeState(status: .ready, pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
-                    makeState(status: .integrating(pr3), pullRequests: [pr1, pr4].map{$0.reference}),
-                    makeState(status: .ready, pullRequests: [pr1, pr4].map{$0.reference}),
-                    makeState(status: .integrating(pr1), pullRequests: [pr4].map{$0.reference}),
-                    makeState(status: .ready, pullRequests: [pr4].map{$0.reference}),
-                    makeState(status: .integrating(pr4)),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [pr2, pr1, pr3, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .integrating(pr2), pullRequests: [pr1, pr3, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .integrating(pr2), pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .runningStatusChecks(pr2.with(mergeState: .blocked)), pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .integrating(pr2.with(mergeState: .clean)), pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .ready, pullRequests: [pr3_tp, pr1, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .integrating(pr3), pullRequests: [pr1, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .ready, pullRequests: [pr1, pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .integrating(pr1), pullRequests: [pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .ready, pullRequests: [pr4].map{$0.reference}),
+                    MergeService.State.stub(status: .integrating(pr4)),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
         }
         )
@@ -805,15 +805,15 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: pullRequests.map { $0.reference }),
-                    makeState(status: .integrating(pullRequests[0]), pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
-                    makeState(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
-                    makeState(status: .integrating(pullRequests[1]), pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
-                    makeState(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
-                    makeState(status: .integrating(pullRequests[2])),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }),
+                    MergeService.State.stub(status: .integrating(pullRequests[0]), pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
+                    MergeService.State.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(2).asArray),
+                    MergeService.State.stub(status: .integrating(pullRequests[1]), pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
+                    MergeService.State.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray),
+                    MergeService.State.stub(status: .integrating(pullRequests[2])),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )
@@ -883,13 +883,13 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
-                    makeState(status: .starting),
-                    makeState(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget)),
-                    makeState(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
-                    makeState(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
-                    makeState(status: .ready),
-                    makeState(status: .idle)
+                    MergeService.State.stub(status: .starting),
+                    MergeService.State.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference]),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget)),
+                    MergeService.State.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked))),
+                    MergeService.State.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean))),
+                    MergeService.State.stub(status: .ready),
+                    MergeService.State.stub(status: .idle)
                 ]
             }
         )

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -168,15 +168,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .success,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .success)
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -208,15 +200,7 @@ class MergeServiceTests: XCTestCase {
             when: { service, scheduler in
                 scheduler.advance()
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .success,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .success)
 
                 scheduler.advance()
             },
@@ -305,15 +289,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .success,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .success)
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -428,15 +404,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .failure,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .failure)
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -484,17 +452,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
 
                 for _ in 1...3 {
-
-                    service.eventsObserver.send(value: .status(
-                        StatusEvent(
-                            sha: "abcdef",
-                            context: "",
-                            description: "N/A",
-                            state: .success,
-                            branches: [StatusEvent.Branch(name: MergeServiceFixture.defaultBranch)]
-                        )
-                    ))
-
+                    service.sendStatusEvent(state: .success)
                     scheduler.advance(by: .seconds(60))
                 }
             },
@@ -638,15 +596,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .failure,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .failure)
 
                 scheduler.advance(by: .seconds(60))
             },
@@ -736,15 +686,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance() // #3
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .success,
-                        branches: [.init(name: pr2.reference.source.ref)]
-                    )
-                ))
+                service.sendStatusEvent(state: .success, branches: [.init(name: pr2.reference.source.ref)])
 
                 scheduler.advance(by: .seconds(60)) // #4
         },
@@ -853,15 +795,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .success,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .success)
 
                 scheduler.advance(by: .seconds(30))
 
@@ -873,15 +807,7 @@ class MergeServiceTests: XCTestCase {
 
                 // Simulate all checks being successful
 
-                service.eventsObserver.send(value: .status(
-                    StatusEvent(
-                        sha: "abcdef",
-                        context: "",
-                        description: "N/A",
-                        state: .success,
-                        branches: [.init(name: MergeServiceFixture.defaultBranch)]
-                    )
-                ))
+                service.sendStatusEvent(state: .success)
 
                 expectedPullRequest = MergeServiceFixture.defaultTarget.with(mergeState: .clean)
                 expectedCommitStatus = CommitState.stub(states: [.success, .success])
@@ -912,6 +838,22 @@ class MergeServiceTests: XCTestCase {
 
         init() {
             (events, eventsObserver) = Signal.pipe()
+        }
+
+        func sendStatusEvent(
+            index: Int = 0,
+            state: StatusEvent.State,
+            branches: [StatusEvent.Branch] = [.init(name: MergeServiceFixture.defaultBranch)]
+        ) {
+            eventsObserver.send(value: .status(
+                StatusEvent(
+                    sha: "abcdef",
+                    context: CommitState.stubContextName(index),
+                    description: "N/A",
+                    state: state,
+                    branches: branches
+                )
+            ))
         }
     }
 

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -921,6 +921,7 @@ class MergeServiceTests: XCTestCase {
         let service = MergeService(
             integrationLabel: LabelFixture.integrationLabel,
             topPriorityLabels: LabelFixture.topPriorityLabels,
+            requiresAllStatusChecks: false,
             statusChecksTimeout: MergeServiceFixture.defaultStatusChecksTimeout,
             logger: MockLogger(),
             gitHubAPI: gitHubAPI,

--- a/Tests/BotTests/MergeService/Stubs/CommitState+Stub.swift
+++ b/Tests/BotTests/MergeService/Stubs/CommitState+Stub.swift
@@ -6,17 +6,8 @@ extension CommitState {
             return CommitState(state: .pending, statuses: [])
         }
 
-        let combinedState: CommitState.State
-        if states.contains(.failure) {
-            combinedState = .failure
-        } else if states.contains(.pending) {
-            combinedState = .pending
-        } else {
-            combinedState = .success
-        }
-
         return .init(
-            state: combinedState,
+            state: CommitState.State.combinedState(for: states),
             statuses: states.enumerated().map { item in
                 CommitState.Status.stub(state: item.element, context: CommitState.stubContextName(item.offset))
             }

--- a/Tests/BotTests/MergeService/Stubs/CommitState+Stub.swift
+++ b/Tests/BotTests/MergeService/Stubs/CommitState+Stub.swift
@@ -1,0 +1,35 @@
+@testable import Bot
+
+extension CommitState {
+    static func stub(states: [CommitState.State]) -> CommitState {
+        guard !states.isEmpty else {
+            return CommitState(state: .pending, statuses: [])
+        }
+
+        let combinedState: CommitState.State
+        if states.contains(.failure) {
+            combinedState = .failure
+        } else if states.contains(.pending) {
+            combinedState = .pending
+        } else {
+            combinedState = .success
+        }
+
+        return .init(
+            state: combinedState,
+            statuses: states.enumerated().map { item in
+                CommitState.Status.stub(state: item.element, context: CommitState.stubContextName(item.offset))
+            }
+        )
+    }
+
+    static func stubContextName(_ index: Int) -> String {
+        return "Check #\(index+1)"
+    }
+}
+
+extension CommitState.Status {
+    static func stub(state: CommitState.State, context: String) -> CommitState.Status {
+        return .init(state: state, description: "\(context) is \(state)", context: context)
+    }
+}

--- a/Tests/BotTests/MergeService/Stubs/MergeService+Stub.swift
+++ b/Tests/BotTests/MergeService/Stubs/MergeService+Stub.swift
@@ -21,20 +21,22 @@ struct MergeServiceFixture {
 
 // MARK: - Helpers
 
-func makeState(
-    status: MergeService.State.Status,
-    pullRequests: [PullRequest] = [],
-    integrationLabel: PullRequest.Label = LabelFixture.integrationLabel,
-    topPriorityLabels: [PullRequest.Label] = LabelFixture.topPriorityLabels,
-    statusChecksTimeout: TimeInterval = MergeServiceFixture.defaultStatusChecksTimeout
-) -> MergeService.State {
-    return .init(
-        integrationLabel: integrationLabel,
-        topPriorityLabels: topPriorityLabels,
-        statusChecksTimeout: statusChecksTimeout,
-        pullRequests: pullRequests,
-        status: status
-    )
+extension MergeService.State {
+    static func stub(
+        status: MergeService.State.Status,
+        pullRequests: [PullRequest] = [],
+        integrationLabel: PullRequest.Label = LabelFixture.integrationLabel,
+        topPriorityLabels: [PullRequest.Label] = LabelFixture.topPriorityLabels,
+        statusChecksTimeout: TimeInterval = MergeServiceFixture.defaultStatusChecksTimeout
+    ) -> MergeService.State {
+        return .init(
+            integrationLabel: integrationLabel,
+            topPriorityLabels: topPriorityLabels,
+            statusChecksTimeout: statusChecksTimeout,
+            pullRequests: pullRequests,
+            status: status
+        )
+    }
 }
 
 extension ArraySlice {

--- a/Tests/BotTests/MergeService/Stubs/RequiredStatusChecks+Stub.swift
+++ b/Tests/BotTests/MergeService/Stubs/RequiredStatusChecks+Stub.swift
@@ -1,0 +1,17 @@
+@testable import Bot
+
+extension RequiredStatusChecks {
+    static func stub(
+        strict: Bool = true,
+        contexts: [String]
+    ) -> RequiredStatusChecks {
+        return .init(strict: strict, contexts: contexts)
+    }
+
+    static func stub(
+        strict: Bool = true,
+        indices: [Int]
+    ) -> RequiredStatusChecks {
+        return .stub(strict: strict, contexts: indices.map(CommitState.stubContextName))
+    }
+}

--- a/Tests/BotTests/MergeService/Stubs/RequiredStatusChecks+Stub.swift
+++ b/Tests/BotTests/MergeService/Stubs/RequiredStatusChecks+Stub.swift
@@ -2,16 +2,16 @@
 
 extension RequiredStatusChecks {
     static func stub(
-        strict: Bool = true,
+        isStrict: Bool = true,
         contexts: [String]
     ) -> RequiredStatusChecks {
-        return .init(strict: strict, contexts: contexts)
+        return .init(isStrict: isStrict, contexts: contexts)
     }
 
     static func stub(
-        strict: Bool = true,
+        isStrict: Bool = true,
         indices: [Int]
     ) -> RequiredStatusChecks {
-        return .stub(strict: strict, contexts: indices.map(CommitState.stubContextName))
+        return .stub(isStrict: isStrict, contexts: indices.map(CommitState.stubContextName))
     }
 }

--- a/Tests/BotTests/Mocks/MockGitHubAPI.swift
+++ b/Tests/BotTests/Mocks/MockGitHubAPI.swift
@@ -10,6 +10,7 @@ struct MockGitHubAPI: GitHubAPIProtocol {
         case getPullRequests(() -> [PullRequest])
         case getPullRequest((UInt) -> PullRequestMetadata)
         case getCommitStatus((PullRequest) -> CommitState)
+        case getRequiredStatusChecks((PullRequest.Branch) -> RequiredStatusChecks)
         case mergePullRequest((PullRequest) -> Void)
         case mergeIntoBranch((PullRequest.Branch, PullRequest.Branch) -> MergeResult)
         case deleteBranch((PullRequest.Branch) -> Void)
@@ -47,6 +48,15 @@ struct MockGitHubAPI: GitHubAPIProtocol {
         switch nextStub() {
         case let .getCommitStatus(handler):
             return SignalProducer(value: handler(pullRequest))
+        default:
+            fatalError("Stub not found")
+        }
+    }
+
+    func fetchRequiredStatusChecks(for branch: PullRequest.Branch) -> SignalProducer<RequiredStatusChecks, AnyError> {
+        switch nextStub() {
+        case let .getRequiredStatusChecks(handler):
+            return SignalProducer(value: handler(branch))
         default:
             fatalError("Stub not found")
         }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-196

## Why?

At the moment Wall-E checks for **all** the checks part of the PR, and refuses to merge it if any of those has failed.

This means there's the assumption that alls checks must pass, but that is not always the case, as some teams have some informative checks included that not always pass, and being informative checks they are not marked as required.

## How?

Wall-E now accepts an environment variable to configure if all checks need to pass or only required checks are required to pass to merge the pull request.

(This is specially needed to enable Wall-E to be used by the Android team)