### PR TITLE
[IOSP-178] Remove redundant step that increases CI time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,9 +35,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: Build image
-          command: make build
-      - run:
           name: Login in quay.io
           command: docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}" quay.io
       - run:


### PR DESCRIPTION
`make install` already builds the image so we are building the image twice.