### PR TITLE
[IOSP-299] Include a route to inform about the current state of the bot

### DIFF
--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -8,6 +8,10 @@ public func routes(
     gitHubEventsService: GitHubEventsService
 ) throws {
 
+    router.get("/") { request -> String in
+        return String(describing: mergeService.state.value)
+    }
+
     router.get("health") { request -> HTTPResponse in
         switch mergeService.healthcheck.status.value {
         case .ok: return HTTPResponse(status: .ok)

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -4,7 +4,7 @@ import ReactiveSwift
 import ReactiveFeedback
 
 public final class MergeService {
-    let state: Property<State>
+    public let state: Property<State>
 
     private let logger: LoggerProtocol
     private let gitHubAPI: GitHubAPIProtocol
@@ -483,7 +483,7 @@ extension MergeService {
 
 extension MergeService {
 
-    enum FailureReason: Equatable {
+    public enum FailureReason: Equatable {
         case conflicts
         case mergeFailed
         case synchronizationFailed
@@ -493,9 +493,9 @@ extension MergeService {
         case unknown
     }
 
-    struct State: Equatable {
+    public struct State: Equatable {
 
-        enum Status: Equatable {
+        public enum Status: Equatable {
             case starting
             case idle
             case ready
@@ -503,7 +503,7 @@ extension MergeService {
             case runningStatusChecks(PullRequestMetadata)
             case integrationFailed(PullRequestMetadata, FailureReason)
 
-            var integrationMetadata: PullRequestMetadata? {
+            internal var integrationMetadata: PullRequestMetadata? {
                 switch self {
                 case let .integrating(metadata):
                     return metadata
@@ -512,7 +512,7 @@ extension MergeService {
                 }
             }
 
-            var statusChecksMetadata: PullRequestMetadata? {
+            internal var statusChecksMetadata: PullRequestMetadata? {
                 switch self {
                 case let .runningStatusChecks(metadata):
                     return metadata
@@ -522,11 +522,11 @@ extension MergeService {
             }
         }
 
-        let integrationLabel: PullRequest.Label
-        let topPriorityLabels: [PullRequest.Label]
-        let statusChecksTimeout: TimeInterval
-        let pullRequests: [PullRequest]
-        let status: Status
+        internal let integrationLabel: PullRequest.Label
+        internal let topPriorityLabels: [PullRequest.Label]
+        internal let statusChecksTimeout: TimeInterval
+        public let pullRequests: [PullRequest]
+        public let status: Status
 
         var isIntegrationOngoing: Bool {
             switch status {
@@ -730,7 +730,7 @@ private extension PullRequest {
     }
 }
 
-extension MergeService.State: CustomDebugStringConvertible {
+extension MergeService.State: CustomStringConvertible {
 
     private var queueDescription: String {
         guard pullRequests.isEmpty == false else { return "[]" }
@@ -745,7 +745,7 @@ extension MergeService.State: CustomDebugStringConvertible {
         return "\(pullRequestsSeparator)\(pullRequestsRepresentation)"
     }
 
-    var debugDescription: String {
+    public var description: String {
         return "State(\n - status: \(status),\n - queue: \(queueDescription)\n)"
     }
 }


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-299

This includes a new route to return the state of the queue as plain text. It will return something along this lines.

```
State(
 - status: idle,
 - queue: []
)
```

The PR in the process of being integrated will be part of `status` and `queue` will contain all PRs waiting to be merged.