### PR TITLE
[IOSP-437] Fix logic when creating MergeService (leading to auto-accepting PRs for new target branches)

### DIFF
--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -88,7 +88,7 @@ public final class DispatchService {
                 return service
             } else {
                 // Only create a new MergeService is the PullRequest for which we received an event is supposed to be included
-                guard case .include(let pullRequest) = MergeService.Event.Outcome(event: event, integrationLabel: self.integrationLabel) else {
+                guard case .include(let pullRequest)? = MergeService.Event.Outcome(event: event, integrationLabel: self.integrationLabel) else {
                     return nil
                 }
 

--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -87,7 +87,7 @@ public final class DispatchService {
                 // If service was already existing, return it so we'll send the pullRequestChangesObserver event outside this `modify` below
                 return service
             } else {
-                // Only create a new MergeService is the PullRequest for which we received an event is supposed to be included
+                // Only create a new MergeService if the PullRequest for which we received an event is supposed to be included
                 guard case .include(let pullRequest)? = MergeService.Event.Outcome(event: event, integrationLabel: self.integrationLabel) else {
                     return nil
                 }

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -586,10 +586,9 @@ extension MergeService {
         return Feedback(predicate: { $0.status != .starting }) { state in
             return pullRequestChanges
                 .observe(on: scheduler)
-                .map { metadata, action in
+                .filterMap { metadata, action in
                     MergeService.Event.Outcome(action: action, metadata: metadata, integrationLabel: state.integrationLabel)
                 }
-                .skipNil()
                 .map(Event.pullRequestDidChange)
         }
     }

--- a/Tests/BotTests/MergeService/DispatchServiceTests.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceTests.swift
@@ -140,6 +140,82 @@ class DispatchServiceTests: XCTestCase {
         )
     }
 
+    func test_creating_new_pull_requests_to_new_target_branch_without_label() {
+        let (developBranch, releaseBranch) = ("develop", "release/app/1.2.3")
+
+        let dev1 = PullRequestMetadata.stub(number: 1, headRef: MergeServiceFixture.defaultBranch, baseRef: developBranch, labels: [LabelFixture.integrationLabel], mergeState: .behind)
+        let dev2 = PullRequestMetadata.stub(number: 2, baseRef: developBranch, labels: [LabelFixture.integrationLabel], mergeState: .clean)
+        let rel3 = PullRequestMetadata.stub(number: 3, baseRef: releaseBranch, mergeState: .clean)
+
+        perform(
+            stubs: [
+                .getPullRequests { [dev1.reference] },
+                .getPullRequest(checkReturnPR(dev1)),
+                .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
+                .mergeIntoBranch { head, base in
+                    expect(head.ref) == MergeServiceFixture.defaultBranch
+                    expect(base.ref) == developBranch
+                    return .success
+                },
+
+                .postComment(checkComment(2, "Your pull request was accepted and it's currently `#1` in the `develop` queue, hold tight ⏳")),
+
+                // Note that here we shouldn't have any API call for PR#3 since it doesn't have the integration label
+                
+                .getPullRequest(checkReturnPR(dev1.with(mergeState: .clean))),
+                .getCommitStatus { pullRequest in
+                    expect(pullRequest.number) == 1
+                    return CommitState.stub(states: [.success])
+                },
+
+                .mergePullRequest(checkPRNumber(1)),
+                .deleteBranch(checkBranch(dev1.reference.source)),
+                .getPullRequest(checkReturnPR(dev2)),
+                .mergePullRequest(checkPRNumber(2)),
+                .deleteBranch(checkBranch(dev2.reference.source)),
+            ],
+            when: { service, scheduler in
+
+                scheduler.advance()
+
+                service.sendPullRequestEvent(action: .synchronize, pullRequestMetadata: dev1.with(mergeState: .blocked))
+
+                scheduler.advance()
+
+                service.sendPullRequestEvent(action: .labeled, pullRequestMetadata: dev2)
+
+                scheduler.advance()
+
+                service.sendPullRequestEvent(action: .opened, pullRequestMetadata: rel3)
+
+                scheduler.advance()
+
+                service.sendStatusEvent(state: .success)
+
+                scheduler.advance(by: .seconds(60))
+            },
+            assert: {
+                expect($0) == [
+                    .created(branch: developBranch),
+                    .state(.stub(targetBranch: developBranch, status: .starting)),
+                    .state(.stub(targetBranch: developBranch, status: .ready, pullRequests: [dev1.reference])),
+                    .state(.stub(targetBranch: developBranch, status: .integrating(dev1))),
+                    .state(.stub(targetBranch: developBranch, status: .runningStatusChecks(dev1.with(mergeState: .blocked)))),
+                    .state(.stub(targetBranch: developBranch, status: .runningStatusChecks(dev1.with(mergeState: .blocked)), pullRequests: [dev2.reference])),
+
+                    // Note: here we want to be sure we don't create a new MergeService for release branch (since the new PR doesn't have the integration label
+
+                    .state(.stub(targetBranch: developBranch, status: .integrating(dev1.with(mergeState: .clean)), pullRequests: [dev2.reference])),
+                    .state(.stub(targetBranch: developBranch, status: .ready, pullRequests: [dev2.reference])),
+                    .state(.stub(targetBranch: developBranch, status: .integrating(dev2))),
+                    .state(.stub(targetBranch: developBranch, status: .ready)),
+                    .state(.stub(targetBranch: developBranch, status: .idle)),
+                    .destroyed(branch: developBranch)
+                ]
+            }
+        )
+    }
+
     func test_json_queue_description() throws {
         let (branch1, branch2) = ("branch1", "branch2")
         let pr1 = PullRequestMetadata.stub(number: 1, headRef: MergeServiceFixture.defaultBranch, baseRef: branch1, labels: [LabelFixture.integrationLabel], mergeState: .behind)

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -39,7 +39,12 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance()
             },
             assert: {
-                expect($0) == []
+                expect($0) == [
+                    .created(branch: MergeServiceFixture.defaultTargetBranch),
+                    .state(.stub(status: .starting)),
+                    .state(.stub(status: .idle)),
+                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch),
+                ]
             }
         )
 
@@ -239,6 +244,12 @@ class MergeServiceTests: XCTestCase {
             },
             assert: {
                 expect($0) == [
+                    // First received new PR with no integration label, so we end up creating the MergeService but destroying it right away since the queue is empty
+                    .created(branch: MergeServiceFixture.defaultTargetBranch),
+                    .state(.stub(status: .starting)),
+                    .state(.stub(status: .idle)),
+                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch),
+                    // Then received PR event about adding integration label, so we end up creating the MergeService again but this time for good
                     .created(branch: MergeServiceFixture.defaultTargetBranch),
                     .state(.stub(status: .starting)),
                     .state(.stub(status: .ready, pullRequests: [targetLabeled.reference])),


### PR DESCRIPTION
Ticket: https://babylonpartners.atlassian.net/browse/IOSP-437

After deploying #39 recently, we realised that there was a flaw in the logic: every time a new Pull Request targeting a branch that doesn't exist yet is created, leading to the creation on a new MergeService, we forgot to filter out those PullRequest events sent by GitHub to only create the new MergeService if that PR was supposed to be included in the first place)

Consequently, any new PR targeting a new target branch was automatically triggering the creation of a new `MergeService` and add that PR to the `MergeService`'s queue… even if that PR didn't have the integration label and wasn't ready to be merged (basically as soon as the PR is created)

This PR fixes that flawed logic.