### PR TITLE
[IOSP-467] [IOSP-468] Prevent MergeBot to comment on closed PRs after merge

### DIFF
--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -31,6 +31,12 @@ extension Environment {
         return TimeInterval(value)
     }
 
+    /// Delay to wait after a MergeService is back in idle state before destroying it
+    static func idleMergeServiceCleanupDelay() throws -> TimeInterval? {
+        let value: String = try Environment.get("IDLE_BRANCH_QUEUE_CLEANUP_DELAY")
+        return TimeInterval(value)
+    }
+
     static func mergeLabel() throws -> PullRequest.Label {
         return PullRequest.Label(name: try Environment.get("MERGE_LABEL"))
     }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -44,6 +44,7 @@ private func makeDispatchService(with logger: LoggerProtocol, _ gitHubEventsServ
         topPriorityLabels: try Environment.topPriorityLabels(),
         requiresAllStatusChecks: try Environment.requiresAllGitHubStatusChecks(),
         statusChecksTimeout: try Environment.statusChecksTimeout() ?? 90.minutes,
+        idleMergeServiceCleanupDelay: try Environment.idleMergeServiceCleanupDelay() ?? 5.minutes,
         logger: logger,
         gitHubAPI: gitHubAPI,
         gitHubEvents: gitHubEventsService

--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -77,6 +77,7 @@ public final class DispatchService {
 
     private func pullRequestDidChange(event: PullRequestEvent) {
         logger.log("📣 Pull Request did change \(event.pullRequestMetadata) with action `\(event.action)`")
+        guard event.action != .closed else { return }
 
         let targetBranch = event.pullRequestMetadata.reference.target.ref
         let existingService = mergeServices.modify { (dict: inout [String: MergeService]) -> MergeService in

--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -133,8 +133,8 @@ public final class DispatchService {
             }
         // Observe idle states to clean up dormant MergeServices only after they have been idle for too long
         mergeService.state.producer
-            .filter { $0.status == .idle }
             .debounce(self.idleMergeServiceCleanupDelay, on: scheduler)
+            .filter { $0.status == .idle }
             .startWithValues { [weak self, service = mergeService, logger = logger] state in
                 guard let self = self else { return }
 

--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -69,7 +69,7 @@ public final class DispatchService {
                 dict[branch] = makeMergeService(
                     targetBranch: branch,
                     scheduler: self.scheduler,
-                    initialTrigger: .booting(openPullRequests: pullRequestsForBranch)
+                    initialPullRequests: pullRequestsForBranch
                 )
             }
         }
@@ -85,8 +85,7 @@ public final class DispatchService {
             } else {
                 let newService = makeMergeService(
                     targetBranch: targetBranch,
-                    scheduler: self.scheduler,
-                    initialTrigger: .gitHubEvent(event)
+                    scheduler: self.scheduler
                 )
                 dict[targetBranch] = newService
                 return newService
@@ -106,7 +105,7 @@ public final class DispatchService {
     private func makeMergeService(
         targetBranch: String,
         scheduler: DateScheduler,
-        initialTrigger: MergeService.InitialTrigger
+        initialPullRequests: [PullRequest] = []
     ) -> MergeService {
         logger.log("🆕 New MergeService created for target branch `\(targetBranch)`")
         let mergeService = MergeService(
@@ -115,7 +114,7 @@ public final class DispatchService {
             topPriorityLabels: topPriorityLabels,
             requiresAllStatusChecks: requiresAllStatusChecks,
             statusChecksTimeout: statusChecksTimeout,
-            initialTrigger: initialTrigger,
+            initialPullRequests: initialPullRequests,
             logger: logger,
             gitHubAPI: gitHubAPI,
             scheduler: scheduler

--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -134,7 +134,6 @@ public final class DispatchService {
         // Observe idle states to clean up dormant MergeServices only after they have been idle for too long
         mergeService.state.producer
             .filter { $0.status == .idle }
-            .skipRepeats()
             .debounce(self.idleMergeServiceCleanupDelay, on: scheduler)
             .startWithValues { [weak self, service = mergeService, logger = logger] state in
                 guard let self = self else { return }

--- a/Sources/Bot/Services/DispatchService.swift
+++ b/Sources/Bot/Services/DispatchService.swift
@@ -123,7 +123,7 @@ public final class DispatchService {
             scheduler: scheduler
         )
 
-        // Forward events about creation and subsequent state changes of the new MS to our lifecycleObserver
+        // Forward events about creation and subsequent state changes of the new MergeService to our lifecycleObserver
         mergeServiceLifecycleObserver.send(value: .created(mergeService))
         mergeService.state.producer
             .skipRepeats()

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -64,7 +64,7 @@ public final class MergeService {
             integrationLabel: integrationLabel,
             topPriorityLabels: topPriorityLabels,
             statusChecksTimeout: statusChecksTimeout,
-            isWaitingForInitialPullRequests: !pullRequestsReadyToInclude.isEmpty
+            isStarting: !pullRequestsReadyToInclude.isEmpty
         )
 
         state = Property<State>(
@@ -154,12 +154,13 @@ extension MergeService {
             self.status = status
         }
 
+        /// - Parameter isStarting: Should only be true if `MergeService` was created as result of a bot reboot, not after a GH event.
         static func initial(
             targetBranch: String,
             integrationLabel: PullRequest.Label,
             topPriorityLabels: [PullRequest.Label],
             statusChecksTimeout: TimeInterval,
-            isWaitingForInitialPullRequests: Bool
+            isStarting: Bool
         ) -> State {
             return State(
                 targetBranch: targetBranch,
@@ -167,7 +168,7 @@ extension MergeService {
                 topPriorityLabels: topPriorityLabels,
                 statusChecksTimeout: statusChecksTimeout,
                 pullRequests: [],
-                status: isWaitingForInitialPullRequests ? .starting : .idle
+                status: isStarting ? .starting : .idle
             )
         }
 

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -109,7 +109,7 @@ extension MergeService {
                 return initialOpenPullRequests.filter { $0.isLabelled(with: integrationLabel) }
             case .gitHubEvent(let event):
                 let outcome = eventOutcome(metadata: event.pullRequestMetadata, action: event.action, integrationLabel: integrationLabel)
-                if case .include(let pullRequest) = outcome {
+                if case .include(let pullRequest)? = outcome {
                     return [pullRequest]
                 } else {
                     return []

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -17,26 +17,27 @@ public final class MergeService {
     private let statusChecksCompletion: Signal<StatusEvent, NoError>
     internal let statusChecksCompletionObserver: Signal<StatusEvent, NoError>.Observer
 
-    /// Instantiate a MergeService for a given target branch.
+    /// Instantiates a `MergeService` for a given target branch.
     ///
-    /// A MergeService is a state machine responsible for handling a queue of Pull Requests,
+    /// A `MergeService` is a state machine responsible for handling a queue of Pull Requests,
     /// merging them in the right order to avoid multiple PRs from conflicting or affecting one another once merged.
     ///
-    /// An instance of a MergeService is responsible for all the Pull Requests targeting the branch it is responsible for.
-    /// There can be multiple MergeServices instances in parallel, each handling the PRs for a different target branch,
-    /// (since it's still safe to merge Pull Requests targeting different branches in parallel).
-    /// Those different MergeServices per target branch are typically managed by a `DispatchService`
+    /// * An instance of a `MergeService` is responsible for all the Pull Requests **targeting a given git branch**.
+    /// * There can be multiple `MergeService` instances in parallel, each handling the PRs for a different target branch,
+    ///   (since it's still safe to merge Pull Requests targeting different branches in parallel).
+    /// * Those different `MergeServices` per target branch are typically managed by a `DispatchService`
     ///
-    /// - Parameter targetBranch: The target branch this MergeService is responsible for
-    /// - Parameter integrationLabel: The GitHub label we want to use to ask the bot to add a PR to the queue
-    /// - Parameter topPriorityLabels: The GitHub label(s) which can be used to bump a PR at the front of the queue
-    /// - Parameter requiresAllStatusChecks: Only merge a PR if _all_ GitHub status checks pass, or only the ones marked as "Required" by GitHub?
-    /// - Parameter statusChecksTimeout: The maximum time to wait for status checks to finish running and update their status
-    /// - Parameter initialPullRequests: Pass the list of open pull requests that are retrieved when the bot starts from scratch, to properly configure its initial state.
-    ///      When creating a MergeService as a result of having received a GitHub event (webhook), keep this parameter empty (then just forward said GitHub event to the `pullRequestsChangesObserver` as usual)
-    /// - Parameter logger: The logger to use to log informative and debug messages
-    /// - Parameter gitHubAPI: The object allowing us to do GitHub API calls
-    /// - Parameter scheduler: RAS DateScheduler
+    /// - Parameters:
+    ///   - targetBranch: The target branch this MergeService is responsible for
+    ///   - integrationLabel: The GitHub label we want to use to ask the bot to add a PR to the queue
+    ///   - topPriorityLabels: The GitHub label(s) which can be used to bump a PR at the front of the queue
+    ///   - requiresAllStatusChecks: Only merge a PR if _all_ GitHub status checks pass, or only the ones marked as "Required" by GitHub?
+    ///   - statusChecksTimeout: The maximum time to wait for status checks to finish running and update their status
+    ///   - initialPullRequests: Pass the list of open pull requests that are retrieved when the bot starts from scratch, to properly configure its initial state.
+    ///      When creating a `MergeService` as a result of having received a GitHub event (webhook), keep this parameter empty (then just forward said GitHub event to the `pullRequestsChangesObserver` as usual)
+    ///   - logger: The logger to use to log informative and debug messages
+    ///   - gitHubAPI: The object allowing us to do GitHub API calls
+    ///   - scheduler: RAS DateScheduler
     public init(
         targetBranch: String,
         integrationLabel: PullRequest.Label,

--- a/Tests/BotTests/MergeService/DispatchServiceContext.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceContext.swift
@@ -1,5 +1,6 @@
 import ReactiveSwift
 import Result
+import Dispatch
 @testable import Bot
 
 enum DispatchServiceEvent: Equatable {
@@ -38,6 +39,7 @@ class DispatchServiceContext {
             topPriorityLabels: LabelFixture.topPriorityLabels,
             requiresAllStatusChecks: requiresAllStatusChecks,
             statusChecksTimeout: MergeServiceFixture.defaultStatusChecksTimeout,
+            idleMergeServiceCleanupDelay: MergeServiceFixture.defaultIdleCleanupDelay,
             logger: MockLogger(),
             gitHubAPI: gitHubAPI,
             gitHubEvents: gitHubEvents,
@@ -51,4 +53,9 @@ class DispatchServiceContext {
                 self?.events.append(event)
             }
     }
+
+    static func idleCleanupDelay(times: Double = 1.0) -> DispatchTimeInterval {
+        return .milliseconds(Int(times * MergeServiceFixture.defaultIdleCleanupDelay * 1000))
+    }
+
 }

--- a/Tests/BotTests/MergeService/DispatchServiceContext.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceContext.swift
@@ -54,8 +54,5 @@ class DispatchServiceContext {
             }
     }
 
-    static func idleCleanupDelay(times: Double = 1.0) -> DispatchTimeInterval {
-        return .milliseconds(Int(times * MergeServiceFixture.defaultIdleCleanupDelay * 1000))
-    }
-
+    static let idleCleanupDelay: DispatchTimeInterval = .milliseconds(Int(MergeServiceFixture.defaultIdleCleanupDelay * 1000))
 }

--- a/Tests/BotTests/MergeService/DispatchServiceContext.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceContext.swift
@@ -54,5 +54,5 @@ class DispatchServiceContext {
             }
     }
 
-    static let idleCleanupDelay: DispatchTimeInterval = .milliseconds(Int(MergeServiceFixture.defaultIdleCleanupDelay * 1000))
+    static let idleCleanupDelay: DispatchTimeInterval = .seconds(Int(MergeServiceFixture.defaultIdleCleanupDelay))
 }

--- a/Tests/BotTests/MergeService/DispatchServiceTests.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceTests.swift
@@ -74,7 +74,6 @@ class DispatchServiceTests: XCTestCase {
                 },
 
                 .postComment(checkComment(2, "Your pull request was accepted and it's currently `#1` in the `develop` queue, hold tight ⏳")),
-
                 .getPullRequest(checkReturnPR(rel3)),
                 .postComment(checkComment(3, "Your pull request was accepted and is going to be handled right away 🏎")),
                 .mergePullRequest(checkPRNumber(3)),

--- a/Tests/BotTests/MergeService/DispatchServiceTests.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceTests.swift
@@ -111,9 +111,10 @@ class DispatchServiceTests: XCTestCase {
                 scheduler.advance()
 
                 // Let the services stay .idle for the cleanup delay so they end up being destroyed
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay(times: 1.5))
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
 
-                scheduler.advance()
+                // Be sure to go way past the cleanup of both MergeServices
+                scheduler.advance(by: .seconds(60))
             },
             assert: {
                 expect($0) == [
@@ -198,7 +199,7 @@ class DispatchServiceTests: XCTestCase {
 
                 scheduler.advance(by: .seconds(60))
 
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay(times: 1.5))
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -50,6 +50,30 @@ class MergeServiceTests: XCTestCase {
 
     }
 
+    func test_pull_request_not_included_on_close() {
+        perform(
+            stubs: [
+                .getPullRequests { [] },
+            ],
+            when: { service, scheduler in
+                scheduler.advance()
+
+                service.sendPullRequestEvent(action: .closed, pullRequestMetadata: MergeServiceFixture.defaultTarget.with(mergeState: .clean))
+
+                scheduler.advance()
+            },
+            assert: {
+                expect($0) == [
+                    .created(branch: MergeServiceFixture.defaultTargetBranch),
+                    .state(.stub(status: .starting)),
+                    .state(.stub(status: .idle)),
+                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch),
+                ]
+            }
+        )
+
+    }
+
     func test_pull_request_with_integration_label_and_ready_to_merge() {
         perform(
             stubs: [
@@ -300,7 +324,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .idle)),
                     .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
                 ]
-        }
+            }
         )
     }
 

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -37,11 +37,11 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { _, scheduler in
                 scheduler.advance()
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
             },
             assert: {
                 expect($0) == [
                     .created(branch: MergeServiceFixture.defaultTargetBranch),
-                    .state(.stub(status: .starting)),
                     .state(.stub(status: .idle)),
                     .destroyed(branch: MergeServiceFixture.defaultTargetBranch),
                 ]
@@ -61,11 +61,12 @@ class MergeServiceTests: XCTestCase {
                 service.sendPullRequestEvent(action: .closed, pullRequestMetadata: MergeServiceFixture.defaultTarget.with(mergeState: .clean))
 
                 scheduler.advance()
+
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
             },
             assert: {
                 expect($0) == [
                     .created(branch: MergeServiceFixture.defaultTargetBranch),
-                    .state(.stub(status: .starting)),
                     .state(.stub(status: .idle)),
                     .destroyed(branch: MergeServiceFixture.defaultTargetBranch),
                 ]
@@ -93,8 +94,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .ready, pullRequests: [MergeServiceFixture.defaultTarget.reference])),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -138,8 +138,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray)),
                     .state(.stub(status: .integrating(pullRequests[2]))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -168,8 +167,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .integrating(target))),
                     .state(.stub(status: .integrationFailed(target, .conflicts))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -208,8 +206,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -242,8 +239,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -283,8 +279,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -305,24 +300,24 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance()
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+
                 service.sendPullRequestEvent(action: .labeled, pullRequestMetadata: targetLabeled)
                 scheduler.advance()
             },
             assert: {
                 expect($0) == [
-                    // First received new PR with no integration label, so we end up creating the MergeService but destroying it right away since the queue is empty
+                    // First received new PR with no integration label, so we end up creating the MergeService but destroying it after some time if the queue stays empty
                     .created(branch: MergeServiceFixture.defaultTargetBranch),
-                    .state(.stub(status: .starting)),
                     .state(.stub(status: .idle)),
                     .destroyed(branch: MergeServiceFixture.defaultTargetBranch),
-                    // Then received PR event about adding integration label, so we end up creating the MergeService again but this time for good
+                    // Then received PR event about adding integration label, so we end up creating the MergeService again but this time handling the PR
                     .created(branch: MergeServiceFixture.defaultTargetBranch),
-                    .state(.stub(status: .starting)),
+                    .state(.stub(status: .idle)),
                     .state(.stub(status: .ready, pullRequests: [targetLabeled.reference])),
                     .state(.stub(status: .integrating(targetLabeled))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -366,6 +361,8 @@ class MergeServiceTests: XCTestCase {
                 service.sendStatusEvent(state: .success)
 
                 scheduler.advance(by: .seconds(60))
+
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
             },
             assert: {
                 expect($0) == [
@@ -404,6 +401,8 @@ class MergeServiceTests: XCTestCase {
                 service.sendPullRequestEvent(action: .closed, pullRequestMetadata: MergeServiceFixture.defaultTarget)
 
                 scheduler.advance()
+
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
             },
             assert: {
                 expect($0) == [
@@ -447,8 +446,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget))),
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -487,8 +485,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .blocked), .checksFailing))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -535,8 +532,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -593,8 +589,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .unstable)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -646,8 +641,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrationFailed(MergeServiceFixture.defaultTarget.with(mergeState: .unstable), .checksFailing))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
         }
         )
@@ -672,7 +666,10 @@ class MergeServiceTests: XCTestCase {
                 service.sendPullRequestEvent(action: .synchronize, pullRequestMetadata: MergeServiceFixture.defaultTarget.with(mergeState: .blocked))
 
                 // 1.5 ensures we trigger the timeout
-                scheduler.advance(by: .minutes(1.5 * MergeServiceFixture.defaultStatusChecksTimeout))
+                scheduler.advance(by: .seconds(Int(1.5 * MergeServiceFixture.defaultStatusChecksTimeout)))
+
+                // ensure MergeService cleanup
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay(times: 1.5))
             },
             assert: {
                 expect($0) == [
@@ -704,6 +701,7 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance(by: .seconds(60))
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay(times: 1.5))
             },
             assert: {
                 expect($0) == [
@@ -736,6 +734,7 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance(by: .seconds(5 * 30))
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
             },
             assert: {
                 expect($0) == [
@@ -784,6 +783,8 @@ class MergeServiceTests: XCTestCase {
                 service.sendStatusEvent(state: .failure)
 
                 scheduler.advance(by: .seconds(60))
+
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
             },
             assert: {
                 expect($0) == [
@@ -890,8 +891,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .ready, pullRequests: [pr4].map{$0.reference})),
                     .state(.stub(status: .integrating(pr4))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
         }
         )
@@ -946,8 +946,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .ready, pullRequests: pullRequests.map { $0.reference }.suffix(1).asArray)),
                     .state(.stub(status: .integrating(pullRequests[2]))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )
@@ -1008,8 +1007,7 @@ class MergeServiceTests: XCTestCase {
                     .state(.stub(status: .runningStatusChecks(MergeServiceFixture.defaultTarget.with(mergeState: .blocked)))),
                     .state(.stub(status: .integrating(MergeServiceFixture.defaultTarget.with(mergeState: .clean)))),
                     .state(.stub(status: .ready)),
-                    .state(.stub(status: .idle)),
-                    .destroyed(branch: MergeServiceFixture.defaultTargetBranch)
+                    .state(.stub(status: .idle))
                 ]
             }
         )

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -37,7 +37,7 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { _, scheduler in
                 scheduler.advance()
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -62,7 +62,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -300,7 +300,7 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance()
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
 
                 service.sendPullRequestEvent(action: .labeled, pullRequestMetadata: targetLabeled)
                 scheduler.advance()
@@ -362,7 +362,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance(by: .seconds(60))
 
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -402,7 +402,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance()
 
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -669,7 +669,7 @@ class MergeServiceTests: XCTestCase {
                 scheduler.advance(by: .seconds(Int(1.5 * MergeServiceFixture.defaultStatusChecksTimeout)))
 
                 // ensure MergeService cleanup
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay(times: 1.5))
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -701,7 +701,7 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance(by: .seconds(60))
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay(times: 1.5))
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -734,7 +734,7 @@ class MergeServiceTests: XCTestCase {
             ],
             when: { service, scheduler in
                 scheduler.advance(by: .seconds(5 * 30))
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [
@@ -784,7 +784,7 @@ class MergeServiceTests: XCTestCase {
 
                 scheduler.advance(by: .seconds(60))
 
-                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay())
+                scheduler.advance(by: DispatchServiceContext.idleCleanupDelay)
             },
             assert: {
                 expect($0) == [

--- a/Tests/BotTests/MergeService/Stubs/MergeService+Stub.swift
+++ b/Tests/BotTests/MergeService/Stubs/MergeService+Stub.swift
@@ -8,6 +8,7 @@ struct LabelFixture {
 
 struct MergeServiceFixture {
     static let defaultStatusChecksTimeout = 30.minutes
+    static let defaultIdleCleanupDelay = 10.minutes
 
     static let defaultBranch = "some-branch"
     static let defaultTargetBranch = "master"


### PR DESCRIPTION
Tickets:
 - https://babylonpartners.atlassian.net/browse/IOSP-467
 - https://babylonpartners.atlassian.net/browse/IOSP-468

## Why?

[IOSP-467] Since recently the bot have been commenting on PRs immediately after them being merged, telling `"Your pull request was accepted and is going to be handled right away 🏎"`… as if the PR was re-added to the queue immediately after being merged

This was because GitHub events for PRs being closed were not filtered out when forwarded to a newly-created MergeService.

## How

* We now forward GitHub `PullRequestEvents` _even_ right after having started a new `MergeService`, so that the GH event goes through the normal state machine – and via the `Feedback.pullRequestChanges` – even immediately after the `MergeService` creation (as opposed to the previous implementation which made a special case of the initialisation and initial Pull Requests passed during a `MergeService`'s instantiation by the `DispatchService` on new event)
* The `MergeService` still processes the initial Pull Requests sent by the `DispatchService` BUT those are *only* sent during the bot's boot sequence – because those don't come from any GitHub webhook/event, but come from a call to the API (to get all open Pull Requests) at bot startup.

---

[IOSP-468] We also now wait for a configurable delay (defaults to 5 minutes) before killing a idle MergeService, to avoid constantly killing and recreating them when there is still some activity on a given branch and queue (like GitHub events close to one another)

---

## Alternatives considered

### Quick and Dirty Fix

Initial quick-fix for IOSP-467 was to just filter-out `.closed` events in the `DispatchService` to avoid creating and dispatching the event to the `MergeService` and thus avoid the comment.

But that meant that we'd leak some logic and implementation details to the `DispatchService`, while it should be up to the `MergeService` to decide if it wants to do something with closed events. Besides, any other event (like `.unlabelled`) could also trigger that bug, not just `.closed` – even though that's the main case where we saw it happen in practice.

### Getting rid of the `.starting` state

I also tried to get rid of the `.starting` state altogether and directly start at the `.idle` or `.ready` state, since this `.starting` state is now only used for the bot's boot sequence (when the list of all open PRs is fetched for initial re-sync)

But the issue is we need a state transition to happen (between `.starting` and `.idle`/`.ready`) at boot, in order to trigger the `Feedback.whenAddingPullRequests` (which derives from `combinePrevious()`) *even during that boot sequence*. Otherwise the service won't post the "Your PR was accepted…" comments on the PRs that are added right after a bot's reboot

### Always starting a new `MergeService` in `.starting` state

If we decide instead that, since we are going to keep the `.starting` state, we might as well always start with it even when the `MergeService` was instantiated after a GitHub event (and not just during the bot's reboot), and let the `MergeService`'s state machine move us to the right state on the next scheduler's tick… then we end up with *two* `Events` emitted by the `Feedbacks` at the same time during the `.starting` state:
 - `.pullRequestsLoaded([])` returned from `whenStarting`
 - `.pullRequestDidChange` return from `pullRequestChanges` (because `DispatchService` forwards the event after having created the `MergeService` if it didn't exist)

Those are emitted exactly at the same time and `.merge()`'d by RAF, and will end up being processed in an _arbitrary_ order – both racing each other, or even one of them ending up being ignored by the state machine. Besides, this is making the state machine non-deterministic (i.e. the next state would depend on which event gets processed first – which is different on Mac vs Linux btw).

This is why this solution has been rejected and we start with `.idle` instead of `.starting` when the `MergeService` is created outside of the bot's reboot sequence, as the only path transitioning out of `.idle` is the `pullRequestDidChange` event and we don't risk to also react to `pullRequestsLoaded` (used to transition out of `.starting`) in that use case.

[IOSP-467]: https://babylonpartners.atlassian.net/browse/IOSP-467
[IOSP-468]: https://babylonpartners.atlassian.net/browse/IOSP-468