### PR TITLE
[IOSP-543] Fix MergeBot deployment

### DIFF
--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -32,13 +32,14 @@ extension Environment {
         return ["yes", "1", "true"].contains(stringValue.lowercased())
     }
 
-    /// Maximum time to wait for a status check to finish running and report a red/green status
+    /// Maximum time (in seconds) to wait for a status check to finish running and report a red/green status
     static func statusChecksTimeout() throws -> TimeInterval? {
         let value: String = try Environment.get("STATUS_CHECKS_TIMEOUT")
         return TimeInterval(value)
     }
 
-    /// Delay to wait after a MergeService is back in idle state before killing it. Defaults to 5 minutes.
+    /// Delay (in seconds) to wait after a MergeService is back in idle state before killing it.
+    /// Defaults to 300 seconds (5 minutes)
     static func idleMergeServiceCleanupDelay() throws -> TimeInterval? {
         let value: String? = Environment.get("IDLE_BRANCH_QUEUE_CLEANUP_DELAY")
         return value.flatMap(TimeInterval.init)

--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -33,8 +33,8 @@ extension Environment {
 
     /// Delay to wait after a MergeService is back in idle state before destroying it
     static func idleMergeServiceCleanupDelay() throws -> TimeInterval? {
-        let value: String = try Environment.get("IDLE_BRANCH_QUEUE_CLEANUP_DELAY")
-        return TimeInterval(value)
+        let value: String? = Environment.get("IDLE_BRANCH_QUEUE_CLEANUP_DELAY")
+        return value.flatMap(TimeInterval.init)
     }
 
     static func mergeLabel() throws -> PullRequest.Label {

--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -3,22 +3,28 @@ import Bot
 
 extension Environment {
 
+    /// GitHub Webhook secret
     static func gitHubWebhookSecret() throws -> String {
         return try Environment.get("GITHUB_WEBHOOK_SECRET")
     }
 
+    /// GitHub Token
     static func gitHubToken() throws -> String {
         return try Environment.get("GITHUB_TOKEN")
     }
 
+    /// GitHub Organisation name (as seen in the github.com/<orgname>/* urls)
     static func gitHubOrganization() throws -> String {
         return try Environment.get("GITHUB_ORGANIZATION")
     }
 
+    /// URL of GitHub Repository to run the MergeBot on
     static func gitHubRepository() throws -> String {
         return try Environment.get("GITHUB_REPOSITORY")
     }
 
+    /// If set to YES/1/TRUE, the Merge Bot will require all GitHub status checks to pass before accepting to merge
+    /// Otherwise, only the GitHub status checks that are marked as "required" in the GitHub settings to pass
     static func requiresAllGitHubStatusChecks() throws -> Bool {
         guard let stringValue: String = Environment.get("REQUIRES_ALL_STATUS_CHECKS") else {
             return false // defaults to only consider required checks
@@ -26,21 +32,24 @@ extension Environment {
         return ["yes", "1", "true"].contains(stringValue.lowercased())
     }
 
+    /// Maximum time to wait for a status check to finish running and report a red/green status
     static func statusChecksTimeout() throws -> TimeInterval? {
         let value: String = try Environment.get("STATUS_CHECKS_TIMEOUT")
         return TimeInterval(value)
     }
 
-    /// Delay to wait after a MergeService is back in idle state before destroying it
+    /// Delay to wait after a MergeService is back in idle state before killing it. Defaults to 5 minutes.
     static func idleMergeServiceCleanupDelay() throws -> TimeInterval? {
         let value: String? = Environment.get("IDLE_BRANCH_QUEUE_CLEANUP_DELAY")
         return value.flatMap(TimeInterval.init)
     }
 
+    /// The text of the GitHub label that you want to use to trigger the MergeBot and add a PR to the queue
     static func mergeLabel() throws -> PullRequest.Label {
         return PullRequest.Label(name: try Environment.get("MERGE_LABEL"))
     }
 
+    /// Comma-separated list of GitHub label names that you want to use to bump a PR's priority – and make it jump to the front of the queue
     static func topPriorityLabels() throws -> [PullRequest.Label] {
         let labelsList: String = try Environment.get("TOP_PRIORITY_LABELS")
         return labelsList.split(separator: ",").map { name in

--- a/Sources/App/Extensions/EnvironmentProperties.swift
+++ b/Sources/App/Extensions/EnvironmentProperties.swift
@@ -33,14 +33,15 @@ extension Environment {
     }
 
     /// Maximum time (in seconds) to wait for a status check to finish running and report a red/green status
-    static func statusChecksTimeout() throws -> TimeInterval? {
-        let value: String = try Environment.get("STATUS_CHECKS_TIMEOUT")
-        return TimeInterval(value)
+    /// Defaults to 5400 (90 minutes)
+    static func statusChecksTimeout() -> TimeInterval? {
+        let value: String? = Environment.get("STATUS_CHECKS_TIMEOUT")
+        return value.flatMap(TimeInterval.init)
     }
 
     /// Delay (in seconds) to wait after a MergeService is back in idle state before killing it.
     /// Defaults to 300 seconds (5 minutes)
-    static func idleMergeServiceCleanupDelay() throws -> TimeInterval? {
+    static func idleMergeServiceCleanupDelay() -> TimeInterval? {
         let value: String? = Environment.get("IDLE_BRANCH_QUEUE_CLEANUP_DELAY")
         return value.flatMap(TimeInterval.init)
     }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -46,8 +46,8 @@ private func makeDispatchService(with logger: LoggerProtocol, _ gitHubEventsServ
         integrationLabel: try Environment.mergeLabel(),
         topPriorityLabels: try Environment.topPriorityLabels(),
         requiresAllStatusChecks: try Environment.requiresAllGitHubStatusChecks(),
-        statusChecksTimeout: try Environment.statusChecksTimeout() ?? 90.minutes,
-        idleMergeServiceCleanupDelay: try Environment.idleMergeServiceCleanupDelay() ?? 5.minutes,
+        statusChecksTimeout: Environment.statusChecksTimeout() ?? 90.minutes,
+        idleMergeServiceCleanupDelay: Environment.idleMergeServiceCleanupDelay() ?? 5.minutes,
         logger: logger,
         gitHubAPI: gitHubAPI,
         gitHubEvents: gitHubEventsService


### PR DESCRIPTION
## Why

One of the newly introduced env var was supposed to be optional, but was implemented as required, which made the last attempt at deploying the MergeBot fail (†)

Also another env var was providing a default value… but implemented as required nonetheless

_(†) We could just have added the env var to the manifest but making this one optional feels more logical, and will avoid failing for the same reason when Android decides to deploy their instance to latest tag too)_

## How

Made the 2 env vars optional, and not `throws` anymore, allowing the default value for it to be useful

Took the occasion to improve env vars doc
