### PR TITLE
[IOSP-590] Restore Queue order on bot reboot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ xcuserdata
 !WallEView.xcodeproj
 Config/secrets
 .DS_Store
+
+# Local files we don't want to commit, like scripts containing secrets
+_local

--- a/Sources/Bot/API/GitHubAPIProtocol.swift
+++ b/Sources/Bot/API/GitHubAPIProtocol.swift
@@ -29,5 +29,10 @@ public protocol GitHubAPIProtocol {
 
     func postComment(_ comment: String, in pullRequest: PullRequest) -> SignalProducer<Void, GitHubClient.Error>
 
+    /// Note: only fetches issue comments, not Pull Request review comments
+    func fetchIssueComments(in pullRequest: PullRequest) -> SignalProducer<[IssueComment], GitHubClient.Error>
+
     func removeLabel(_ label: PullRequest.Label, from pullRequest: PullRequest) -> SignalProducer<Void, GitHubClient.Error>
+
+    func fetchCurrentUser() -> SignalProducer<GitHubUser, GitHubClient.Error>
 }

--- a/Sources/Bot/API/Repository.swift
+++ b/Sources/Bot/API/Repository.swift
@@ -113,7 +113,7 @@ extension Repository {
                 default:
                     return .failure(.api(response))
                 }
-        }
+            }
         )
     }
 

--- a/Sources/Bot/API/Repository.swift
+++ b/Sources/Bot/API/Repository.swift
@@ -92,6 +92,14 @@ extension Repository {
         )
     }
 
+    func issueComments(in pullRequest: PullRequest) -> Resource<[IssueComment]> {
+        return Resource(
+            method: .GET,
+            path: path(for: "issues/\(pullRequest.number)/comments"),
+            decoder: decode
+        )
+    }
+
     func merge(head: PullRequest.Branch, into base: PullRequest.Branch) -> Resource<MergeResult> {
         return Resource(
             method: .POST,
@@ -114,6 +122,14 @@ extension Repository {
             method: .PUT,
             path: path(for: "pulls/\(pullRequest.number)/merge"),
             body: encode(MergePullRequestRequest(with: pullRequest)),
+            decoder: decode
+        )
+    }
+
+    var currentUser: Resource<GitHubUser> {
+        Resource(
+            method: .GET,
+            path: "user",
             decoder: decode
         )
     }

--- a/Sources/Bot/API/RepositoryAPI.swift
+++ b/Sources/Bot/API/RepositoryAPI.swift
@@ -49,8 +49,16 @@ public struct RepositoryAPI: GitHubAPIProtocol {
         return client.request(repository.publish(comment: comment, in: pullRequest))
     }
 
+    public func fetchIssueComments(in pullRequest: PullRequest) -> SignalProducer<[IssueComment], GitHubClient.Error> {
+        return client.request(repository.issueComments(in: pullRequest))
+    }
+
     public func removeLabel(_ label: PullRequest.Label, from pullRequest: PullRequest) -> SignalProducer<Void, GitHubClient.Error> {
         return client.request(repository.removeLabel(label: label, from: pullRequest))
+    }
+
+    public func fetchCurrentUser() -> SignalProducer<GitHubUser, GitHubClient.Error> {
+        return client.request(repository.currentUser)
     }
 }
 

--- a/Sources/Bot/Models/GitHubUser.swift
+++ b/Sources/Bot/Models/GitHubUser.swift
@@ -3,5 +3,5 @@ import Foundation
 public struct GitHubUser: Identifiable, Equatable, Decodable {
     public let id: Int
     let login: String
-    let name: String
+    let name: String?
 }

--- a/Sources/Bot/Models/GitHubUser.swift
+++ b/Sources/Bot/Models/GitHubUser.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public struct GitHubUser: Identifiable, Equatable, Decodable {
+    public let id: Int
+    let login: String
+    let name: String
+}

--- a/Sources/Bot/Models/IssueComment.swift
+++ b/Sources/Bot/Models/IssueComment.swift
@@ -7,28 +7,9 @@ public struct IssueComment: Equatable {
 }
 
 extension IssueComment: Decodable {
-    private static let dateFormatter: DateFormatter = {
-        // 2020-03-30T11:26:18
-        let df = DateFormatter()
-        df.locale = Locale(identifier: "en_US_POSIX")
-        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
-        return df
-    }()
-
     private enum CodingKeys: String, CodingKey {
         case user
         case body
-        case created_at
-    }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.user = try container.decode(GitHubUser.self, forKey: .user)
-        self.body = try container.decode(String.self, forKey: .body)
-        let dateString = try container.decode(String.self, forKey: .created_at)
-        guard let date = Self.dateFormatter.date(from: dateString) else {
-            throw DecodingError.dataCorruptedError(forKey: .created_at, in: container, debugDescription: "Invalid date format")
-        }
-        self.creationDate = date
+        case creationDate = "created_at"
     }
 }

--- a/Sources/Bot/Models/IssueComment.swift
+++ b/Sources/Bot/Models/IssueComment.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct IssueComment: Equatable {
+    let user: GitHubUser
+    let body: String
+    let creationDate: Date
+}
+
+extension IssueComment: Decodable {
+    private static let dateFormatter: DateFormatter = {
+        // 2020-03-30T11:26:18
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+        return df
+    }()
+
+    private enum CodingKeys: String, CodingKey {
+        case user
+        case body
+        case created_at
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.user = try container.decode(GitHubUser.self, forKey: .user)
+        self.body = try container.decode(String.self, forKey: .body)
+        let dateString = try container.decode(String.self, forKey: .created_at)
+        guard let date = Self.dateFormatter.date(from: dateString) else {
+            throw DecodingError.dataCorruptedError(forKey: .created_at, in: container, debugDescription: "Invalid date format")
+        }
+        self.creationDate = date
+    }
+}

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -391,8 +391,9 @@ extension MergeService {
                 .map { comments in
                     let lastBotComment = comments
                         .filter(isBotMergeComment)
-                        .max { $0.creationDate < $1.creationDate }
-                    return (pullRequest, lastBotComment?.creationDate ?? .distantFuture)
+                        .map { $0.creationDate }
+                        .max()
+                    return (pullRequest, lastBotComment ?? .distantFuture)
                 }
         }
 

--- a/Sources/Bot/Services/MergeService.swift
+++ b/Sources/Bot/Services/MergeService.swift
@@ -389,11 +389,11 @@ extension MergeService {
             return gitHubAPI.fetchIssueComments(in: pullRequest)
                 .flatMapError { _ in .value([]) }
                 .map { comments in
-                    let lastBotComment = comments
+                    let lastBotCommentDate = comments
                         .filter(isBotMergeComment)
                         .map { $0.creationDate }
                         .max()
-                    return (pullRequest, lastBotComment ?? .distantFuture)
+                    return (pullRequest, lastBotCommentDate ?? .distantFuture)
                 }
         }
 

--- a/Tests/BotTests/Canned Data/GitHubIssueComment.swift
+++ b/Tests/BotTests/Canned Data/GitHubIssueComment.swift
@@ -1,0 +1,52 @@
+let GitHubIssueComment = #"""
+{
+  "url": "https://api.github.com/repos/babylonhealth/Wall-E/pulls/comments/400979441",
+  "pull_request_review_id": 384816651,
+  "id": 400979441,
+  "node_id": "MDI0OlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDQwMDk3OTQ0MQ==",
+  "diff_hunk": "@@ -0,0 +1,34 @@\n+import Foundation\n+\n+public struct IssueComment: Equatable {\n+    let user: GitHubUser\n+    let body: String\n+    let creationDate: Date\n+}\n+\n+extension IssueComment: Decodable {\n+    private static let dateFormatter: DateFormatter = {\n+        // 2020-03-30T11:26:18\n+        let df = DateFormatter()\n+        df.locale = Locale(identifier: \"en_US_POSIX\")\n+        df.dateFormat = \"yyyy-MM-dd'T'HH:mm:ssZ\"\n+        return df\n+    }()\n+\n+    private enum CodingKeys: String, CodingKey {\n+        case user\n+        case body\n+        case created_at\n+    }\n+\n+    public init(from decoder: Decoder) throws {\n+        let container = try decoder.container(keyedBy: CodingKeys.self)\n+        self.user = try container.decode(GitHubUser.self, forKey: .user)\n+        self.body = try container.decode(String.self, forKey: .body)\n+        let dateString = try container.decode(String.self, forKey: .created_at)\n+        guard let date = Self.dateFormatter.date(from: dateString) else {",
+  "path": "Sources/Bot/Models/IssueComment.swift",
+  "position": 29,
+  "original_position": 29,
+  "commit_id": "8b6a72d20ab8f5cb6cd6d6bf9300bb14fdb9e681",
+  "original_commit_id": "8b6a72d20ab8f5cb6cd6d6bf9300bb14fdb9e681",
+  "user": {
+    "login": "AliSoftware",
+    "id": 216089,
+    "node_id": "MDQ6VXNlcjIxNjA4OQ==",
+    "avatar_url": "https://avatars2.githubusercontent.com/u/216089?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/AliSoftware",
+    "html_url": "https://github.com/AliSoftware",
+    "followers_url": "https://api.github.com/users/AliSoftware/followers",
+    "following_url": "https://api.github.com/users/AliSoftware/following{/other_user}",
+    "gists_url": "https://api.github.com/users/AliSoftware/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/AliSoftware/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/AliSoftware/subscriptions",
+    "organizations_url": "https://api.github.com/users/AliSoftware/orgs",
+    "repos_url": "https://api.github.com/users/AliSoftware/repos",
+    "events_url": "https://api.github.com/users/AliSoftware/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/AliSoftware/received_events",
+    "type": "User",
+    "site_admin": false
+  },
+  "body": "Oh forgot about that one, good point.\r\nAnd just saw that there's actually already code for that in `Decoding.swift` so all that shouldn't even be needed at all indeed. ",
+  "created_at": "2020-03-31T14:54:28Z",
+  "updated_at": "2020-03-31T14:54:28Z",
+  "html_url": "https://github.com/babylonhealth/Wall-E/pull/57#discussion_r400979441",
+  "pull_request_url": "https://api.github.com/repos/babylonhealth/Wall-E/pulls/57",
+  "author_association": "CONTRIBUTOR",
+  "_links": {
+    "self": {
+      "href": "https://api.github.com/repos/babylonhealth/Wall-E/pulls/comments/400979441"
+    },
+    "html": {
+      "href": "https://github.com/babylonhealth/Wall-E/pull/57#discussion_r400979441"
+    },
+    "pull_request": {
+      "href": "https://api.github.com/repos/babylonhealth/Wall-E/pulls/57"
+    }
+  },
+  "in_reply_to_id": 400977181
+}
+"""#

--- a/Tests/BotTests/GitHub/GitHubDecodingTests.swift
+++ b/Tests/BotTests/GitHub/GitHubDecodingTests.swift
@@ -60,5 +60,15 @@ class GitHubDecodingTests: XCTestCase {
             fail("Could not parse a pull request with error: \(error)")
         }
     }
+
+    func test_parsing_issue_comment() throws {
+        let response = Bot.Response(statusCode: 200, headers: [:], body: GitHubIssueComment.data(using: .utf8)!)
+        let commentResult: Result<IssueComment, GitHubClient.Error> = Bot.decode(response)
+        let comment = try commentResult.get()
+        expect(comment.user.id) == 216089
+        expect(comment.user.login) == "AliSoftware"
+        expect(comment.body) == "Oh forgot about that one, good point.\r\nAnd just saw that there's actually already code for that in `Decoding.swift` so all that shouldn't even be needed at all indeed. "
+        expect(comment.creationDate.timeIntervalSince1970) == 1585666468
+    }
 }
 

--- a/Tests/BotTests/MergeService/DispatchServiceTests.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceTests.swift
@@ -16,7 +16,11 @@ class DispatchServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { pullRequests.map { $0.reference } },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
                 .getPullRequest(returnPR()),
                 .postComment { _, _ in },
                 .getPullRequest(returnPR()),
@@ -62,7 +66,9 @@ class DispatchServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [dev1.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest(checkReturnPR(dev1)),
                 .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
                 .mergeIntoBranch { head, base in
@@ -149,7 +155,9 @@ class DispatchServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [dev1.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest(checkReturnPR(dev1)),
                 .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
                 .mergeIntoBranch { head, base in
@@ -239,8 +247,9 @@ class DispatchServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [prs[0].reference] },
-
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in prs[0] },
                 .postComment { _, _ in },
                 .mergePullRequest { _ in },
@@ -325,11 +334,12 @@ class DispatchServiceTests: XCTestCase {
     }
 
     func test_mergeservice_destroyed_when_idle_after_boot() {
-        let pr = PullRequestMetadata.stub(number: 1)
+        let pr = PullRequestMetadata.stub(number: 1) // No Merge label, so should get filtered out
         let branch = pr.reference.target.ref
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [pr.reference] },
             ],
             when: { service, scheduler in
@@ -352,7 +362,9 @@ class DispatchServiceTests: XCTestCase {
         let pr3 = PullRequestMetadata.stub(number: 3, baseRef: branch2, labels: [LabelFixture.integrationLabel], mergeState: .behind)
 
         let stubs: [MockGitHubAPI.Stubs] = [
+            .getCurrentUser { nil },
             .getPullRequests { [pr1.reference] },
+            .getIssueComments { _ in [] },
             .getPullRequest(checkReturnPR(pr1)),
             .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
             .mergeIntoBranch { _, _ in .success },

--- a/Tests/BotTests/MergeService/DispatchServiceTests.swift
+++ b/Tests/BotTests/MergeService/DispatchServiceTests.swift
@@ -70,16 +70,16 @@ class DispatchServiceTests: XCTestCase {
                 .getPullRequests { [dev1.reference] },
                 .getIssueComments { _ in [] },
                 .getPullRequest(checkReturnPR(dev1)),
-                .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
+                .postComment(checkComment(1, MergeService.acceptedCommentText(index: nil, queue: "develop", isBooting: true))),
                 .mergeIntoBranch { head, base in
                     expect(head) == dev1.reference.source
                     expect(base) == dev1.reference.target
                     return .success
                 },
 
-                .postComment(checkComment(2, "Your pull request was accepted and it's currently #\u{200B}1 in the `develop` queue, hold tight ⏳")),
+                .postComment(checkComment(2, MergeService.acceptedCommentText(index: 0, queue: "develop"))),
                 .getPullRequest(checkReturnPR(rel3)),
-                .postComment(checkComment(3, "Your pull request was accepted and is going to be handled right away 🏎")),
+                .postComment(checkComment(3, MergeService.acceptedCommentText(index: nil, queue: "release/app/1.2.3"))),
                 .mergePullRequest(checkPRNumber(3)),
                 .deleteBranch(checkBranch(rel3.reference.source)),
 
@@ -159,14 +159,14 @@ class DispatchServiceTests: XCTestCase {
                 .getPullRequests { [dev1.reference] },
                 .getIssueComments { _ in [] },
                 .getPullRequest(checkReturnPR(dev1)),
-                .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
+                .postComment(checkComment(1, MergeService.acceptedCommentText(index: nil, queue: "develop", isBooting: true))),
                 .mergeIntoBranch { head, base in
                     expect(head.ref) == MergeServiceFixture.defaultBranch
                     expect(base.ref) == developBranch
                     return .success
                 },
 
-                .postComment(checkComment(2, "Your pull request was accepted and it's currently #\u{200B}1 in the `develop` queue, hold tight ⏳")),
+                .postComment(checkComment(2, MergeService.acceptedCommentText(index: 0, queue: "develop"))),
 
                 // Note that here we shouldn't have any API call for PR#3 since it doesn't have the integration label
                 
@@ -366,11 +366,11 @@ class DispatchServiceTests: XCTestCase {
             .getPullRequests { [pr1.reference] },
             .getIssueComments { _ in [] },
             .getPullRequest(checkReturnPR(pr1)),
-            .postComment(checkComment(1, "Your pull request was accepted and is going to be handled right away 🏎")),
+            .postComment(checkComment(1, MergeService.acceptedCommentText(index: nil, queue: "branch1", isBooting: true))),
             .mergeIntoBranch { _, _ in .success },
-            .postComment(checkComment(2, "Your pull request was accepted and it's currently #\u{200B}1 in the `branch1` queue, hold tight ⏳")),
+            .postComment(checkComment(2, MergeService.acceptedCommentText(index: 0, queue: "branch1"))),
             .getPullRequest(checkReturnPR(pr3)),
-            .postComment(checkComment(3, "Your pull request was accepted and is going to be handled right away 🏎")),
+            .postComment(checkComment(3, MergeService.acceptedCommentText(index: nil, queue: "branch2"))),
             .mergeIntoBranch { _, _ in .success },
         ]
 

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -89,10 +89,10 @@ class MergeServiceTests: XCTestCase {
 
             switch pullRequest.number {
             case 10:
-                // With a bot comment in March --> ordered second
+                // With last bot comment in March --> ordered second
                 return [
-                    makeDevComment(month: 3, day: 1),
-                    makeDevComment(month: 3, day: 2),
+                    makeDevComment(month: 1, day: 1),
+                    makeDevComment(month: 1, day: 2),
                     makeBotComment(month: 3, day: 3),
                     makeDevComment(month: 3, day: 4)
                 ]
@@ -103,12 +103,12 @@ class MergeServiceTests: XCTestCase {
                     makeDevComment(month: 2, day: 2)
                 ]
             case 12:
-                // With a bot comment in Jan --> ordered first
+                // With last bot comment in Jan --> ordered first
                 return [
-                    makeDevComment(month: 1, day: 1),
-                    makeDevComment(month: 1, day: 2),
-                    makeBotComment(month: 1, day: 3),
-                    makeDevComment(month: 1, day: 4)
+                    makeDevComment(month: 1, day: 10),
+                    makeDevComment(month: 1, day: 11),
+                    makeBotComment(month: 1, day: 12),
+                    makeDevComment(month: 1, day: 13)
                 ]
             default:
                 fatalError("Unexpected PullRequest number")

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -82,7 +82,7 @@ class MergeServiceTests: XCTestCase {
             func makeBotComment(year: Int = 2020, month: Int, day: Int) -> IssueComment {
                 return IssueComment(
                     user: botUser,
-                    body: "\(MergeService.acceptedCommentIntro) and blah",
+                    body: MergeService.acceptedCommentText(index: 2, queue: "somequeue", isBooting: true),
                     creationDate: makeDate(year: year, month: month, day: day)
                 )
             }
@@ -125,9 +125,9 @@ class MergeServiceTests: XCTestCase {
             }
         }
 
-        func expectComment(_ expectedMessageSuffix: String, _ expectedPRNum: UInt) -> (String, PullRequest) -> Void {
+        func expectComment(_ expectedIndex: Int?, _ expectedPRNum: UInt) -> (String, PullRequest) -> Void {
             return { postedMessage, pullRequest in
-                expect(postedMessage) == "Your pull request was accepted and \(expectedMessageSuffix)"
+                expect(postedMessage) == MergeService.acceptedCommentText(index: expectedIndex, queue: "master", isBooting: true)
                 expect(pullRequest.number) == expectedPRNum
             }
         }
@@ -140,9 +140,9 @@ class MergeServiceTests: XCTestCase {
                 .getIssueComments(mockComments),
                 .getIssueComments(mockComments),
                 .getPullRequest(expectPR(12)),
-                .postComment(expectComment("is going to be handled right away 🏎", 12)),
-                .postComment(expectComment("it's currently #​2 in the `master` queue, hold tight ⏳", 10)),
-                .postComment(expectComment("it's currently #​3 in the `master` queue, hold tight ⏳", 11)),
+                .postComment(expectComment(nil, 12)),
+                .postComment(expectComment(1, 10)),
+                .postComment(expectComment(2, 11)),
                 .mergePullRequest { _ in },
                 .deleteBranch { _ in },
                 .getPullRequest(expectPR(10)),
@@ -475,7 +475,7 @@ class MergeServiceTests: XCTestCase {
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
                 .postComment { message, pullRequest in
-                    expect(message) == "Your pull request was accepted and it's currently #\u{200B}1 in the `master` queue, hold tight ⏳"
+                    expect(message) == MergeService.acceptedCommentText(index: 0, queue: "master")
                     expect(pullRequest.number) == 2
                 },
                 .getPullRequest { _ in first.with(mergeState: .clean) },
@@ -1082,15 +1082,15 @@ class MergeServiceTests: XCTestCase {
                 .getIssueComments { _ in [] },
                 .getPullRequest { _ in pullRequests[0] },
                 .postComment { message, pullRequest in
-                    expect(message) == "Your pull request was accepted and is going to be handled right away 🏎"
+                    expect(message) == MergeService.acceptedCommentText(index: nil, queue: "master", isBooting: true)
                     expect(pullRequest.number) == 144
                 },
                 .postComment { message, pullRequest in
-                    expect(message) == "Your pull request was accepted and it's currently #\u{200B}2 in the `master` queue, hold tight ⏳"
+                    expect(message) == MergeService.acceptedCommentText(index: 1, queue: "master", isBooting: true)
                     expect(pullRequest.number) == 233
                 },
                 .postComment { message, pullRequest in
-                    expect(message) == "Your pull request was accepted and it's currently #\u{200B}3 in the `master` queue, hold tight ⏳"
+                    expect(message) == MergeService.acceptedCommentText(index: 2, queue: "master", isBooting: true)
                     expect(pullRequest.number) == 377
                 },
                 .mergePullRequest { _ in },

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -14,6 +14,7 @@ class MergeServiceTests: XCTestCase {
     func test_empty_list_of_pull_requests_should_do_nothing() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [] }
             ],
             when: { _, scheduler in
@@ -28,6 +29,7 @@ class MergeServiceTests: XCTestCase {
     func test_no_pull_requests_with_integration_label() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [
                     PullRequestMetadata.stub(number: 1).reference,
                     PullRequestMetadata.stub(number: 2).reference
@@ -52,6 +54,7 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_not_included_on_close() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [] },
             ],
             when: { service, scheduler in
@@ -77,7 +80,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_with_integration_label_and_ready_to_merge() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .clean) },
                 .postComment { _, _ in },
                 .mergePullRequest { _ in },
@@ -109,7 +114,11 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { pullRequests.map { $0.reference } },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in pullRequests[0] },
                 .postComment { _, _ in },
                 .postComment { _, _ in },
@@ -149,7 +158,9 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [target.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in target },
                 .postComment { _, _ in },
                 .postComment { _, _ in },
@@ -175,7 +186,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_with_integration_label_and_behind_target_branch() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -214,7 +227,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_blocked_with_successful_status_no_pending_checks() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .blocked) },
                 .postComment { _, _ in },
                 .getAllStatusChecks { _ in [.init(state: .success, context: "", description: "")]},
@@ -247,7 +262,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_blocked_with_successful_status_pending_checks() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .blocked) },
                 .postComment { _, _ in },
                 .getAllStatusChecks { _ in
@@ -290,7 +307,9 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [target.reference] },
+                // target.reference is not labelled with Merge label, so we're not fetching issue comments on whenStarting :)
                 .getPullRequest { _ in targetLabeled },
                 .postComment { _, _ in },
                 .mergePullRequest { _ in },
@@ -328,7 +347,9 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [first.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in first },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -384,7 +405,9 @@ class MergeServiceTests: XCTestCase {
     func test_closing_pull_request_during_integration() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success }
@@ -420,7 +443,9 @@ class MergeServiceTests: XCTestCase {
     func test_removing_the_integration_label_during_integration() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success }
@@ -453,7 +478,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_with_status_checks_failing() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -494,7 +521,9 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -542,7 +571,9 @@ class MergeServiceTests: XCTestCase {
         perform(
             requiresAllStatusChecks: false,
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -597,7 +628,9 @@ class MergeServiceTests: XCTestCase {
         perform(
             requiresAllStatusChecks: true,
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -649,7 +682,9 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _ in },
                 .mergeIntoBranch { _, _ in .success },
@@ -688,7 +723,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_with_an_initial_unknown_state_with_recover() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .unknown) },
                 .postComment { _, _ in },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .unknown) },
@@ -719,7 +756,9 @@ class MergeServiceTests: XCTestCase {
     func test_pull_request_with_an_initial_unknown_state_without_recover() {
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .unknown) },
                 .postComment { _, _ in },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget.with(mergeState: .unknown) },
@@ -756,7 +795,10 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [first, second].map { $0.reference} },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in first },
                 .postComment { _, _ in },
                 .postComment { _, _ in },
@@ -827,7 +869,12 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { Array(allPRs).map { $0.reference} },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
                 // advance() #1
                 .getPullRequest { (num: UInt) -> PullRequestMetadata in
                     expect(num) == 2
@@ -907,7 +954,11 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { pullRequests.map { $0.reference } },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in pullRequests[0] },
                 .postComment { message, pullRequest in
                     expect(message) == "Your pull request was accepted and is going to be handled right away 🏎"
@@ -958,7 +1009,9 @@ class MergeServiceTests: XCTestCase {
 
         perform(
             stubs: [
+                .getCurrentUser { nil },
                 .getPullRequests { [MergeServiceFixture.defaultTarget.reference] },
+                .getIssueComments { _ in [] },
                 .getPullRequest { _ in MergeServiceFixture.defaultTarget },
                 .postComment { _, _  in },
                 .mergeIntoBranch { _, _ in .success },

--- a/Tests/BotTests/MergeService/MergeServiceTests.swift
+++ b/Tests/BotTests/MergeService/MergeServiceTests.swift
@@ -91,24 +91,24 @@ class MergeServiceTests: XCTestCase {
             case 10:
                 // With last bot comment in March --> ordered second
                 return [
-                    makeDevComment(month: 1, day: 1),
-                    makeDevComment(month: 1, day: 2),
-                    makeBotComment(month: 3, day: 3),
-                    makeDevComment(month: 3, day: 4)
+                    makeBotComment(month: 1, day: 1), // 🤖 -- it's a trap, comment in 1 Jan but not the last
+                    makeDevComment(month: 1, day: 2), // 👨‍💻
+                    makeBotComment(month: 3, day: 3), // 🤖 -- last bot comment = 3 Mar
+                    makeDevComment(month: 3, day: 4)  // 👩‍💻
                 ]
             case 11:
                 // Without any bot comment --> ordered last
                 return [
-                    makeDevComment(month: 2, day: 1),
-                    makeDevComment(month: 2, day: 2)
+                    makeDevComment(month: 2, day: 1), // 👨‍💻
+                    makeDevComment(month: 2, day: 2)  // 👩‍💻
                 ]
             case 12:
                 // With last bot comment in Jan --> ordered first
                 return [
-                    makeDevComment(month: 1, day: 10),
-                    makeDevComment(month: 1, day: 11),
-                    makeBotComment(month: 1, day: 12),
-                    makeDevComment(month: 1, day: 13)
+                    makeBotComment(month: 1, day: 10), // 🤖 -- it's a trap, comment after the first one for PR#10 but not the last
+                    makeDevComment(month: 1, day: 11), // 👩‍💻
+                    makeBotComment(month: 1, day: 12), // 🤖 -- last bot comment = 12 Jan
+                    makeDevComment(month: 1, day: 13)  // 👨‍💻
                 ]
             default:
                 fatalError("Unexpected PullRequest number")


### PR DESCRIPTION
# Why?

When the docker image / Kubernetes pod hosting our bot reboots, the queue was rebuilt from the list of labelled PRs, but the order of the queue was arbitrary

# How?

## Ordering of Pull Requests on boot

The bot now orders the Pull Requests by date at which the bot last commented about the PR being picked up.

* At startup, the bot fetches the list of all open Pull Requests, as it did before, and filtered them to only keep the ones with Merge label, to get the list of initial PRs to start the queue with. But instead of using that unordered list directly, now it also does the following:
* for each of those filtered PR, we fetch the list of GitHub comments, filter only for comments by the bot matching "Your pull request was accepted […]" body, and find the latest one of those. This gives us a date for when the PR was previously last added to the queue by the bot
* Once we have those clue dates for each PR, we order the list of PRs by those dates. If we didn't find a bot comment for a PR, we assume a date of `.distantFuture` which will make those PR go to the end of the list

## Bot comments

The bot now mention in the comment when a PR was picked because of a reboot (and the bot rebuilding its initial queue) or not (and the bot adding a PR because you just added the Merge label)

# Tested?

Added a dedicated unit test for it
